### PR TITLE
fix: Kill child npm/ng processes when host process exits

### DIFF
--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Internals/NodeScriptRunner.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Internals/NodeScriptRunner.cs
@@ -127,6 +127,8 @@ internal sealed class NodeScriptRunner : IDisposable
 			// See equivalent comment in OutOfProcessNodeInstance.cs for why
 			process.EnableRaisingEvents = true;
 
+			ProcessTracker.AddProcess(process);
+
 			return process;
 		}
 		catch (Exception ex)

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Internals/ProcessTracker.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Internals/ProcessTracker.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace MintPlayer.AspNetCore.SpaServices.Prerendering.Internals;
+
+/// <summary>
+/// Ensures child processes are terminated when the parent process exits.
+/// On Windows, uses a Job Object with <c>JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE</c> so the OS
+/// automatically kills children even on abrupt termination (e.g., stopping the VS debugger).
+/// On all platforms, also registers an <see cref="AppDomain.ProcessExit"/> handler as a fallback.
+/// </summary>
+internal static class ProcessTracker
+{
+	private static readonly List<Process> s_trackedProcesses = new();
+	private static readonly nint s_jobHandle;
+
+	static ProcessTracker()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			s_jobHandle = CreateJobObject(nint.Zero, null);
+			if (s_jobHandle != nint.Zero)
+			{
+				var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+				{
+					BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+					{
+						LimitFlags = 0x2000 // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+					}
+				};
+
+				var length = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+				var infoPtr = Marshal.AllocHGlobal(length);
+				try
+				{
+					Marshal.StructureToPtr(info, infoPtr, false);
+					SetInformationJobObject(s_jobHandle, 9 /* ExtendedLimitInformation */, infoPtr, (uint)length);
+				}
+				finally
+				{
+					Marshal.FreeHGlobal(infoPtr);
+				}
+			}
+		}
+
+		AppDomain.CurrentDomain.ProcessExit += (_, _) => KillTrackedProcesses();
+	}
+
+	public static void AddProcess(Process process)
+	{
+		if (OperatingSystem.IsWindows() && s_jobHandle != nint.Zero)
+		{
+			AssignProcessToJobObject(s_jobHandle, process.Handle);
+		}
+
+		lock (s_trackedProcesses)
+		{
+			s_trackedProcesses.Add(process);
+		}
+	}
+
+	private static void KillTrackedProcesses()
+	{
+		lock (s_trackedProcesses)
+		{
+			foreach (var process in s_trackedProcesses)
+			{
+				try
+				{
+					if (!process.HasExited)
+					{
+						process.Kill(entireProcessTree: true);
+					}
+				}
+				catch
+				{
+					// Best effort — process may have already exited
+				}
+			}
+
+			s_trackedProcesses.Clear();
+		}
+	}
+
+	[DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+	private static extern nint CreateJobObject(nint lpJobAttributes, string? lpName);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool SetInformationJobObject(nint hJob, int jobObjectInfoClass, nint lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool AssignProcessToJobObject(nint hJob, nint hProcess);
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+	{
+		public long PerProcessUserTimeLimit;
+		public long PerJobUserTimeLimit;
+		public uint LimitFlags;
+		public nuint MinimumWorkingSetSize;
+		public nuint MaximumWorkingSetSize;
+		public uint ActiveProcessLimit;
+		public nint Affinity;
+		public uint PriorityClass;
+		public uint SchedulingClass;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct IO_COUNTERS
+	{
+		public ulong ReadOperationCount;
+		public ulong WriteOperationCount;
+		public ulong OtherOperationCount;
+		public ulong ReadTransferCount;
+		public ulong WriteTransferCount;
+		public ulong OtherTransferCount;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	{
+		public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+		public IO_COUNTERS IoInfo;
+		public nuint ProcessMemoryLimit;
+		public nuint JobMemoryLimit;
+		public nuint PeakProcessMemoryUsed;
+		public nuint PeakJobMemoryUsed;
+	}
+}

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/MintPlayer.AspNetCore.SpaServices.Prerendering.csproj
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/MintPlayer.AspNetCore.SpaServices.Prerendering.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices.Prerendering</PackageId>
-		<Version>10.4.0</Version>
+		<Version>10.5.0</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices/MintPlayer.AspNetCore.SpaServices.csproj
+++ b/MintPlayer.AspNetCore.SpaServices/MintPlayer.AspNetCore.SpaServices.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices</PackageId>
-		<Version>10.4.0</Version>
+		<Version>10.5.0</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices/Npm/NodeScriptRunner.cs
+++ b/MintPlayer.AspNetCore.SpaServices/Npm/NodeScriptRunner.cs
@@ -140,6 +140,8 @@ internal sealed class NodeScriptRunner : IDisposable
 			// See equivalent comment in OutOfProcessNodeInstance.cs for why
 			process.EnableRaisingEvents = true;
 
+			ProcessTracker.AddProcess(process);
+
 			return process;
 		}
 		catch (Exception ex)

--- a/MintPlayer.AspNetCore.SpaServices/Npm/ProcessTracker.cs
+++ b/MintPlayer.AspNetCore.SpaServices/Npm/ProcessTracker.cs
@@ -1,0 +1,134 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+
+namespace MintPlayer.AspNetCore.SpaServices.Npm;
+
+/// <summary>
+/// Ensures child processes are terminated when the parent process exits.
+/// On Windows, uses a Job Object with <c>JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE</c> so the OS
+/// automatically kills children even on abrupt termination (e.g., stopping the VS debugger).
+/// On all platforms, also registers an <see cref="AppDomain.ProcessExit"/> handler as a fallback.
+/// </summary>
+internal static class ProcessTracker
+{
+	private static readonly List<Process> s_trackedProcesses = new();
+	private static readonly nint s_jobHandle;
+
+	static ProcessTracker()
+	{
+		if (OperatingSystem.IsWindows())
+		{
+			s_jobHandle = CreateJobObject(nint.Zero, null);
+			if (s_jobHandle != nint.Zero)
+			{
+				var info = new JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+				{
+					BasicLimitInformation = new JOBOBJECT_BASIC_LIMIT_INFORMATION
+					{
+						LimitFlags = 0x2000 // JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE
+					}
+				};
+
+				var length = Marshal.SizeOf<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>();
+				var infoPtr = Marshal.AllocHGlobal(length);
+				try
+				{
+					Marshal.StructureToPtr(info, infoPtr, false);
+					SetInformationJobObject(s_jobHandle, 9 /* ExtendedLimitInformation */, infoPtr, (uint)length);
+				}
+				finally
+				{
+					Marshal.FreeHGlobal(infoPtr);
+				}
+			}
+		}
+
+		AppDomain.CurrentDomain.ProcessExit += (_, _) => KillTrackedProcesses();
+	}
+
+	public static void AddProcess(Process process)
+	{
+		if (OperatingSystem.IsWindows() && s_jobHandle != nint.Zero)
+		{
+			AssignProcessToJobObject(s_jobHandle, process.Handle);
+		}
+
+		lock (s_trackedProcesses)
+		{
+			s_trackedProcesses.Add(process);
+		}
+	}
+
+	private static void KillTrackedProcesses()
+	{
+		lock (s_trackedProcesses)
+		{
+			foreach (var process in s_trackedProcesses)
+			{
+				try
+				{
+					if (!process.HasExited)
+					{
+						process.Kill(entireProcessTree: true);
+					}
+				}
+				catch
+				{
+					// Best effort — process may have already exited
+				}
+			}
+
+			s_trackedProcesses.Clear();
+		}
+	}
+
+	[DllImport("kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+	private static extern nint CreateJobObject(nint lpJobAttributes, string? lpName);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool SetInformationJobObject(nint hJob, int jobObjectInfoClass, nint lpJobObjectInfo, uint cbJobObjectInfoLength);
+
+	[DllImport("kernel32.dll", SetLastError = true)]
+	[return: MarshalAs(UnmanagedType.Bool)]
+	private static extern bool AssignProcessToJobObject(nint hJob, nint hProcess);
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct JOBOBJECT_BASIC_LIMIT_INFORMATION
+	{
+		public long PerProcessUserTimeLimit;
+		public long PerJobUserTimeLimit;
+		public uint LimitFlags;
+		public nuint MinimumWorkingSetSize;
+		public nuint MaximumWorkingSetSize;
+		public uint ActiveProcessLimit;
+		public nint Affinity;
+		public uint PriorityClass;
+		public uint SchedulingClass;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct IO_COUNTERS
+	{
+		public ulong ReadOperationCount;
+		public ulong WriteOperationCount;
+		public ulong OtherOperationCount;
+		public ulong ReadTransferCount;
+		public ulong WriteTransferCount;
+		public ulong OtherTransferCount;
+	}
+
+	[StructLayout(LayoutKind.Sequential)]
+	private struct JOBOBJECT_EXTENDED_LIMIT_INFORMATION
+	{
+		public JOBOBJECT_BASIC_LIMIT_INFORMATION BasicLimitInformation;
+		public IO_COUNTERS IoInfo;
+		public nuint ProcessMemoryLimit;
+		public nuint JobMemoryLimit;
+		public nuint PeakProcessMemoryUsed;
+		public nuint PeakJobMemoryUsed;
+	}
+}


### PR DESCRIPTION
## Summary
- When stopping the VS debugger, the .NET host is terminated abruptly so `IHostApplicationLifetime.ApplicationStopping` never fires and the `npm start` / `ng serve` child processes become orphaned (ports remain occupied)
- Adds `ProcessTracker` that uses a Windows Job Object with `JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE` so the OS automatically kills child processes when the parent handle closes — even on abrupt termination
- Also registers an `AppDomain.ProcessExit` handler as a cross-platform fallback for graceful shutdowns

## Test plan
- [ ] Launch multiple SPA projects via VS debugger (e.g. Fleet, HR, SparkId)
- [ ] Verify `ng serve` processes start and ports are accessible
- [ ] Stop the debugger and confirm the `ng serve` processes are killed and ports are released
- [ ] Verify normal `dotnet run` + Ctrl+C still cleans up properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)