### PR TITLE
Handling of request cancellation & bugfix for reading originalhtml

### DIFF
--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
@@ -125,6 +125,13 @@ public static class SpaPrerenderingExtensions
 					}
 				}
 
+				// If the request has been aborted, there's no point in continuing with prerendering.
+				// outputBuffer might also be empty or in an incomplete state.
+				if (context.RequestAborted.IsCancellationRequested)
+				{
+					return;
+				}
+
 				// If it isn't an HTML page that we can use as the template for prerendering,
 				//  - ... because it's not text/html
 				//  - ... or because it's an error

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
@@ -189,7 +189,7 @@ public static class SpaPrerenderingExtensions
 		return applicationBuilder;
 	}
 
-	private static bool IsHtmlContentType(string contentType)
+	private static bool IsHtmlContentType(string? contentType)
 	{
 		// Media types are case-insensitive (RFC 9110 8.3.1), and optional whitespace is allowed
 		// before the ';' that starts the parameters. Comparing Ordinal against a lowercase literal

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
@@ -146,7 +146,7 @@ public static class SpaPrerenderingExtensions
 				// a template from which the fully prerendered page can be generated.
 				var customData = new Dictionary<string, object>
 				{
-					{ "originalHtml", Encoding.UTF8.GetString(outputBuffer.GetBuffer()) }
+					{ "originalHtml", Encoding.UTF8.GetString(outputBuffer.GetBuffer(), 0, (int)outputBuffer.Length) }
 				};
 
 				// If the developer wants to use custom logic to pass arbitrary data to the


### PR DESCRIPTION
First of - thanks for providing & maintaining this package!

I have been hunting some regular errors we only seen production system for years, and I finally think I (with a lot of AI) figured out what happens.

This PR fixes two different issues, but both resulting in approximately the same symptom, which is that originalHtml ends up empty/corrupt, and thus Node fails with NG05104 error.

It's unfortunately very difficult to test / create test for - I tried a few weeks ago creating a Console app to do it, as I thought it was a race condition, but it's hard to emulate how the browsers abort the request and how .NET handles that. It might even be different between IIS and Kestrel as well, so not sure how to add test coverage for this.

About the fix for cancellation - I originally added this to the "canPrerender" check, I thought it more clear to be explicit. Also, await outputBuffer.CopyToAsync(context.Response.Body); might throw if cancelled, so would need to check whether cancelled twice.

### First issue
(AI summary of the issue)
UseSpaPrerendering builds the originalHtml template passed to the prerenderer by decoding the captured response buffer with MemoryStream.GetBuffer(). GetBuffer() returns the stream's internal array (its Capacity), which is typically larger than the number of bytes actually written (Length) and is padded with stale/zero bytes. Decoding it without a length therefore produces an HTML string that is longer than the real response and can contain garbage — and, depending on buffer state, can also surface truncated content. This intermittently corrupts the template handed to the JS prerenderer.

### Second issue
(AI summary of the issue)
In SpaPrerenderingExtensions.UseSpaPrerendering() the .Body is substituted by a MemoryStream to capture the output of the StaticFileMiddleware - but it appears that the code continue into SSR even when the client request has already been canceled/aborted, and the read of the buffer ends up empty. Due to how the static middleware works, the ContentLength and ContentType on the Response might be set, but the Body is not written in case of cancellation. That then leaves originalHtml empty, and the middleware calls into Node prerendering (and OnSupplyData) with an empty template, which makes Angular throw an NG05104 error.