### PR TITLE
Reject partial and undecodable prerender templates, and fix the 10.7.0 HEAD regression

### DIFF
--- a/MintPlayer.AspNetCore.NodeServices/MintPlayer.AspNetCore.NodeServices.csproj
+++ b/MintPlayer.AspNetCore.NodeServices/MintPlayer.AspNetCore.NodeServices.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.NodeServices</PackageId>
-		<Version>10.7.0</Version>
+		<Version>10.7.1</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices.Abstractions/MintPlayer.AspNetCore.SpaServices.Abstractions.csproj
+++ b/MintPlayer.AspNetCore.SpaServices.Abstractions/MintPlayer.AspNetCore.SpaServices.Abstractions.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices.Abstractions</PackageId>
-		<Version>10.7.0</Version>
+		<Version>10.7.1</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/MintPlayer.AspNetCore.SpaServices.Prerendering.csproj
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/MintPlayer.AspNetCore.SpaServices.Prerendering.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices.Prerendering</PackageId>
-		<Version>10.7.0</Version>
+		<Version>10.7.1</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
@@ -3,6 +3,7 @@
 
 using System.Text;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.Extensions.Primitives;
 using Microsoft.Net.Http.Headers;
 using MintPlayer.AspNetCore.NodeServices;
 
@@ -74,7 +75,16 @@ public static class SpaPrerenderingExtensions
 		var excludePathStrings = (options.ExcludeUrls ?? Array.Empty<string>())
 			.Select(url => new PathString(url))
 			.ToArray();
-		var logger = Internals.LoggerFinder.GetOrCreateLogger(applicationBuilder, nameof(UseSpaPrerendering));
+		// The full type name, not "UseSpaPrerendering": a bare method name is not reachable through
+		// the conventional Logging:LogLevel:<namespace> configuration, so a consumer could not turn
+		// this middleware's Debug lines on without turning on everything.
+		var logger = Internals.LoggerFinder.GetOrCreateLogger(applicationBuilder, typeof(SpaPrerenderingExtensions).FullName!);
+
+		// Latches the first "template does not look like a whole document" warning. Scoped to this
+		// UseSpaPrerendering call rather than static, which is the right lifetime, and kept as an
+		// int for Interlocked. A fragment template is legitimate, so warning on every request would
+		// be the same mistake as warning on every HEAD.
+		var structureWarningIssued = 0;
 
 		applicationBuilder.Use(async (context, next) =>
 		{
@@ -97,6 +107,26 @@ public static class SpaPrerenderingExtensions
 					await next();
 					return;
 				}
+			}
+
+			// Prerendering only makes sense for GET. A HEAD carries no body to capture, so it used
+			// to reach the empty-template guard and log a warning for entirely healthy traffic;
+			// anything else either never reaches a template at all or would be prerendered into a
+			// response where a rendered page is meaningless.
+			//
+			// Placed before the build await on purpose: without that ordering a POST or an OPTIONS
+			// to a SPA route blocks on `ng build` before being turned away downstream. Placed after
+			// the exclude loop so the skip is not logged for static asset paths, and after
+			// Response.OnStarting so OnPrepareResponse still runs for every method.
+			if (!HttpMethods.IsGet(context.Request.Method))
+			{
+				logger.LogDebug(
+					"Skipping prerendering of {Path}: prerendering applies to GET requests, and this is a {Method}.",
+					context.Request.Path,
+					context.Request.Method);
+
+				await next();
+				return;
 			}
 
 			if (bootModuleBuildTask != null)
@@ -177,11 +207,95 @@ public static class SpaPrerenderingExtensions
 				// response as-is. Note that the non-text/html case is not an error: this is
 				// typically how the SPA dev server responses for static content are returned
 				// in development mode.
-				var canPrerender = IsSuccessStatusCode(context.Response.StatusCode)
-					&& IsHtmlContentType(context.Response.ContentType);
-					//&& IsNotRedirect(context.Response.StatusCode);
-				if (!canPrerender)
+				if (!IsHtmlContentType(context.Response.ContentType))
 				{
+					await PassThroughAsync(context, outputBuffer);
+					return;
+				}
+
+				// Beyond "is it HTML", the capture has to be the *whole* document. Being 2xx and
+				// text/html does not establish that, which is how a 206 range response - a
+				// one-byte slice of index.html - was accepted as a template.
+				//
+				// Note the status must be exactly 200 rather than any 2xx. That fails closed on
+				// statuses nobody has considered yet, where "2xx except the ones we know about"
+				// fails open. A 206 is rejected even when its range covers the entire file, because
+				// its Content-Range framing cannot survive a body we rewrite.
+				// A status that carries no body at all is a benign reason to have nothing to
+				// prerender, so it is reported at Debug. Warning is reserved for a response that
+				// was supposed to be a document and is not - otherwise this category teaches
+				// consumers to ignore it, which is the mistake the HEAD warning made.
+				if (!CanHaveResponseBody(context))
+				{
+					logger.LogDebug(
+						"Skipping prerendering of {Path}: status {StatusCode} carries no response body, so there is no template.",
+						context.Request.Path,
+						context.Response.StatusCode);
+
+					await PassThroughAsync(context, outputBuffer);
+					return;
+				}
+
+				if (context.Response.StatusCode != StatusCodes.Status200OK
+					|| context.Response.Headers.ContainsKey(HeaderNames.ContentRange))
+				{
+					logger.LogWarning(
+						"Skipping prerendering of {Path}: the captured response is a partial representation ({Method}, status {StatusCode}, Content-Range \"{ContentRange}\").",
+						context.Request.Path,
+						context.Request.Method,
+						context.Response.StatusCode,
+						context.Response.Headers[HeaderNames.ContentRange].ToString());
+
+					await PassThroughAsync(context, outputBuffer);
+					return;
+				}
+
+				// Accept-Encoding is stripped from the request above so that we capture plain text,
+				// but nothing verified the result. A capture that is still encoded would be decoded
+				// as UTF-8 and hand the prerenderer compressed bytes.
+				if (!IsIdentityContentEncoding(context.Response.Headers[HeaderNames.ContentEncoding]))
+				{
+					logger.LogWarning(
+						"Skipping prerendering of {Path}: the captured response is encoded as \"{ContentEncoding}\", which cannot be used as a template.",
+						context.Request.Path,
+						context.Response.Headers[HeaderNames.ContentEncoding].ToString());
+
+					await PassThroughAsync(context, outputBuffer);
+					return;
+				}
+
+				// A declared length that does not match what was actually written means the body
+				// was truncated or never flushed, whatever the status says. Only a short capture is
+				// rejected: a *longer* one cannot be a truncation, and a response-transforming
+				// middleware that legitimately shrinks the body (HTML minification, for instance)
+				// updates ContentLength as it goes - if it did not, every response on every route
+				// that this middleware never touches would already fail Kestrel's own
+				// Content-Length verification.
+				if (context.Response.ContentLength.HasValue && outputBuffer.Length < context.Response.ContentLength)
+				{
+					logger.LogWarning(
+						"Skipping prerendering of {Path}: only {CapturedBytes} of the {DeclaredBytes} declared bytes were captured, so the template is incomplete.",
+						context.Request.Path,
+						outputBuffer.Length,
+						context.Response.ContentLength);
+
+					await PassThroughAsync(context, outputBuffer);
+					return;
+				}
+
+				// Bytes that are not valid UTF-8 cannot be a template. Checked on the bytes rather
+				// than by inspecting the decoded string for U+FFFD, which cannot tell corrupt input
+				// apart from a template legitimately containing a replacement character, and rather
+				// than decoding with throwOnInvalidBytes, which would throw on the request path and
+				// leave nothing to log.
+				if (!IsValidUtf8(outputBuffer))
+				{
+					logger.LogWarning(
+						"Skipping prerendering of {Path}: the captured {CapturedBytes} bytes are not valid UTF-8 (Content-Type \"{ContentType}\"), so they cannot be a template.",
+						context.Request.Path,
+						outputBuffer.Length,
+						context.Response.ContentType);
+
 					await PassThroughAsync(context, outputBuffer);
 					return;
 				}
@@ -193,17 +307,61 @@ public static class SpaPrerenderingExtensions
 
 				// An empty template is never something the prerenderer can work with, and handing
 				// it to Node is what produces an unhelpful NG05104 instead of a diagnosable
-				// message. There is no known benign cause, so this is worth a warning.
+				// message. The one benign producer of an empty capture - a HEAD request, which
+				// carries headers but no body - is turned away before the capture is installed, so
+				// reaching this point on a GET means the body genuinely was never written. It also
+				// covers a chunked empty response, where the declared-length check above is silent.
 				if (string.IsNullOrWhiteSpace(originalHtml))
 				{
 					logger.LogWarning(
-						"Skipping prerendering of {Path}: the captured response was empty ({CapturedBytes} of {DeclaredBytes} declared bytes), so there is no template to prerender.",
+						"Skipping prerendering of {Path}: the captured response was empty ({Method}, status {StatusCode}, {CapturedBytes} of {DeclaredBytes} declared bytes), so there is no template to prerender.",
 						context.Request.Path,
+						context.Request.Method,
+						context.Response.StatusCode,
 						outputBuffer.Length,
 						context.Response.ContentLength);
 
 					await PassThroughAsync(context, outputBuffer);
 					return;
+				}
+
+				// A NUL cannot appear in a conforming HTML document - the HTML parser replaces it -
+				// so its presence means the bytes were not the text they claimed to be. The case
+				// this catches is a non-UTF-8 charset: UTF-16 markup is byte-wise valid UTF-8 for
+				// its ASCII half and decodes to "<\0!\0d\0...", which is neither empty nor
+				// whitespace and so passed every earlier check straight into NG05104.
+				if (originalHtml.Contains('\0'))
+				{
+					logger.LogWarning(
+						"Skipping prerendering of {Path}: the captured {CapturedBytes} bytes decoded to text containing NUL characters (Content-Type \"{ContentType}\"), which is not a usable template. Template begins: {TemplateHead}",
+						context.Request.Path,
+						outputBuffer.Length,
+						context.Response.ContentType,
+						DescribeTemplateHead(originalHtml));
+
+					await PassThroughAsync(context, outputBuffer);
+					return;
+				}
+
+				// Diagnostic only, never a rejection. A fragment template is a legitimate if
+				// unusual deployment - the renderer normalizes a bare "<app-root></app-root>" into
+				// a full document - so failing the request here would break a working application.
+				// Warned once and then only at Debug: a fragment deployment must not emit a warning
+				// per request forever, but a consumer whose template is silently wrong needs to see
+				// something at default level at least once.
+				if (!LooksLikeWholeDocument(originalHtml))
+				{
+					const string structureMessage =
+						"The prerender template for {Path} has no <html> element ({TemplateLength} characters). This is supported, but if prerendering is failing it is the first thing to check. Template begins: {TemplateHead}";
+
+					if (Interlocked.Exchange(ref structureWarningIssued, 1) == 0)
+					{
+						logger.LogWarning(structureMessage, context.Request.Path, originalHtml.Length, DescribeTemplateHead(originalHtml));
+					}
+					else
+					{
+						logger.LogDebug(structureMessage, context.Request.Path, originalHtml.Length, DescribeTemplateHead(originalHtml));
+					}
 				}
 
 				var customData = new Dictionary<string, object>
@@ -270,13 +428,26 @@ public static class SpaPrerenderingExtensions
 	/// </remarks>
 	private static async Task PassThroughAsync(HttpContext context, MemoryStream outputBuffer)
 	{
-		if (context.Response.ContentLength.HasValue && context.Response.ContentLength != outputBuffer.Length)
+		// Only for a response that is allowed to carry a body. "Zero bytes written contradicts the
+		// declared length" is only true when a body was expected: a HEAD reports the length the
+		// equivalent GET would return and deliberately sends nothing, and 204/205/304 have no body
+		// by definition. Rewriting those to 0 discards correct metadata - which is exactly what
+		// this did to every HEAD.
+		if (CanHaveResponseBody(context)
+			&& context.Response.ContentLength.HasValue
+			&& context.Response.ContentLength != outputBuffer.Length)
 		{
 			context.Response.ContentLength = outputBuffer.Length;
 		}
 
 		await outputBuffer.CopyToAsync(context.Response.Body);
 	}
+
+	private static bool CanHaveResponseBody(HttpContext context)
+		=> !HttpMethods.IsHead(context.Request.Method)
+			&& context.Response.StatusCode is not (StatusCodes.Status204NoContent
+				or StatusCodes.Status205ResetContent
+				or StatusCodes.Status304NotModified);
 
 	/// <summary>
 	/// Decodes the captured response body into the HTML template handed to the prerenderer.
@@ -338,6 +509,64 @@ public static class SpaPrerenderingExtensions
 	private static bool IsSuccessStatusCode(int statusCode)
 		=> statusCode >= 200 && statusCode < 300;
 
+	/// <summary>
+	/// Whether the captured response was left unencoded, so that it can be decoded as text.
+	/// </summary>
+	/// <remarks>
+	/// An absent header is the normal case, since <c>Accept-Encoding</c> is stripped from the
+	/// request before the capture. An explicit <c>identity</c> is honoured; anything else is a
+	/// content coding this middleware cannot undo, and a multi-value header means at least one
+	/// coding was applied even if one of them is <c>identity</c>.
+	/// </remarks>
+	private static bool IsIdentityContentEncoding(StringValues contentEncoding)
+	{
+		if (contentEncoding.Count == 0)
+		{
+			return true;
+		}
+
+		if (contentEncoding.Count > 1)
+		{
+			return false;
+		}
+
+		var value = contentEncoding[0];
+
+		return string.IsNullOrEmpty(value)
+			|| string.Equals(value.Trim(), "identity", StringComparison.OrdinalIgnoreCase);
+	}
+
+	/// <summary>
+	/// Whether the captured bytes are valid UTF-8, checked without decoding them.
+	/// </summary>
+	private static bool IsValidUtf8(MemoryStream outputBuffer)
+	{
+		if (!outputBuffer.TryGetBuffer(out var buffer))
+		{
+			return System.Text.Unicode.Utf8.IsValid(outputBuffer.ToArray());
+		}
+
+		return System.Text.Unicode.Utf8.IsValid(buffer.AsSpan());
+	}
+
+	/// <summary>
+	/// Whether the template looks like a complete HTML document. A heuristic, used only to decide
+	/// whether to log - never to reject a template.
+	/// </summary>
+	private static bool LooksLikeWholeDocument(string html)
+		=> html.Contains("<html", StringComparison.OrdinalIgnoreCase)
+			&& html.Contains("</html", StringComparison.OrdinalIgnoreCase);
+
+	/// <summary>
+	/// The first 200 characters of a template, on a single line, for a log message.
+	/// </summary>
+	private static string DescribeTemplateHead(string html)
+	{
+		var head = html.Length <= 200 ? html : html[..200];
+
+		return head.ReplaceLineEndings(" ");
+	}
+
 	private static void RemoveConditionalRequestHeaders(HttpRequest request)
 	{
 		request.Headers.Remove(HeaderNames.IfMatch);
@@ -345,6 +574,20 @@ public static class SpaPrerenderingExtensions
 		request.Headers.Remove(HeaderNames.IfNoneMatch);
 		request.Headers.Remove(HeaderNames.IfUnmodifiedSince);
 		request.Headers.Remove(HeaderNames.IfRange);
+
+		// Range, for the same reason as the conditional headers above: we need the whole document
+		// to use as a template, and a Range request makes StaticFileMiddleware answer 206 with a
+		// slice of it. `Range: bytes=0-0` yielded a one-byte template - the "<" of "<!doctype html>".
+		//
+		// Removing If-Range while keeping Range was actively harmful, not merely incomplete:
+		// StaticFileContext.ComputeIfRange is the only code that can cancel an already-parsed
+		// range, so stripping If-Range guaranteed the range was always honoured.
+		//
+		// Unlike Accept-Encoding this is NOT restored afterwards. That restore is functionally
+		// required - it happens before ServePrerenderResult writes, and upstream compression
+		// middleware reads the header at first write - whereas nothing downstream of the capture
+		// reads Range. A prerendered body cannot satisfy a byte range in any case.
+		request.Headers.Remove(HeaderNames.Range);
 	}
 
 	private static string GetAndRemoveAcceptEncodingHeader(HttpRequest request)

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
@@ -349,6 +349,11 @@ public static class SpaPrerenderingExtensions
 				// Warned once and then only at Debug: a fragment deployment must not emit a warning
 				// per request forever, but a consumer whose template is silently wrong needs to see
 				// something at default level at least once.
+				//
+				// Only the opening <html tag is looked for, never a closing </html>. Those end tags
+				// are optional per the HTML standard *and* are removed by every mainstream HTML
+				// minifier, so requiring one warns about perfectly healthy documents - see the
+				// remarks on LooksLikeWholeDocument for the detail.
 				if (!LooksLikeWholeDocument(originalHtml))
 				{
 					const string structureMessage =
@@ -554,12 +559,30 @@ public static class SpaPrerenderingExtensions
 	/// whether to log - never to reject a template.
 	/// </summary>
 	/// <remarks>
-	/// Only the opening tag is required. Requiring a closing <c>&lt;/html&gt;</c> as well produced a
-	/// false positive on any template that had been through an HTML minifier: the end tags for
-	/// <c>html</c> and <c>body</c> are optional, so aggressive minification legitimately removes
-	/// them, and a perfectly good minified document was reported as having no <c>&lt;html&gt;</c>
-	/// element at all. The opening tag is not optional and is not stripped, so it carries the whole
-	/// signal on its own.
+	/// <para>
+	/// Only the opening tag is checked, deliberately. This originally required a closing
+	/// <c>&lt;/html&gt;</c> as well, which turned out to be a false positive on any template that had
+	/// been through an HTML minifier - it reported a perfectly healthy document, one that visibly
+	/// starts with <c>&lt;html lang=en&gt;</c>, as having no <c>&lt;html&gt;</c> element at all.
+	/// </para>
+	/// <para>
+	/// There are two independent reasons a valid document may have no <c>&lt;/html&gt;</c>. First,
+	/// the HTML Living Standard makes the end tags for <c>html</c> and <c>body</c> *omissible* - an
+	/// <c>html</c> end tag may be omitted when it is not immediately followed by a comment - so a
+	/// document ending at <c>&lt;/div&gt;</c> is not malformed, and the parser closes them
+	/// implicitly. Second, and this is what was actually observed, removing those optional end tags
+	/// is a standard minifier optimisation: WebMarkupMin has <c>RemoveOptionalEndTags</c> and
+	/// html-minifier-terser has <c>removeOptionalTags</c>, and a minifier registered *inside* the
+	/// SPA callback runs downstream of this capture. In the demo that turns a 547-byte
+	/// <c>index.html</c> ending in <c>&lt;/body&gt;&lt;/html&gt;</c> into a 456-character template
+	/// with neither.
+	/// </para>
+	/// <para>
+	/// The opening tag survives all of that: no build tool emits a document without one, and no
+	/// minifier strips it. It carries the whole signal on its own - a genuine fragment template
+	/// (<c>&lt;app-root&gt;&lt;/app-root&gt;</c>) has no <c>&lt;html</c> anywhere, and neither does a
+	/// mid-document byte range.
+	/// </para>
 	/// </remarks>
 	private static bool LooksLikeWholeDocument(string html)
 		=> html.Contains("<html", StringComparison.OrdinalIgnoreCase);

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs
@@ -553,9 +553,16 @@ public static class SpaPrerenderingExtensions
 	/// Whether the template looks like a complete HTML document. A heuristic, used only to decide
 	/// whether to log - never to reject a template.
 	/// </summary>
+	/// <remarks>
+	/// Only the opening tag is required. Requiring a closing <c>&lt;/html&gt;</c> as well produced a
+	/// false positive on any template that had been through an HTML minifier: the end tags for
+	/// <c>html</c> and <c>body</c> are optional, so aggressive minification legitimately removes
+	/// them, and a perfectly good minified document was reported as having no <c>&lt;html&gt;</c>
+	/// element at all. The opening tag is not optional and is not stripped, so it carries the whole
+	/// signal on its own.
+	/// </remarks>
 	private static bool LooksLikeWholeDocument(string html)
-		=> html.Contains("<html", StringComparison.OrdinalIgnoreCase)
-			&& html.Contains("</html", StringComparison.OrdinalIgnoreCase);
+		=> html.Contains("<html", StringComparison.OrdinalIgnoreCase);
 
 	/// <summary>
 	/// The first 200 characters of a template, on a single line, for a log message.

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/README.md
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/README.md
@@ -30,18 +30,32 @@ The pipeline order that makes this work is therefore:
 2. Inside its callback, `spa.UseSpaPrerendering(...)` is registered **before** `spa.UseAngularCliServer(...)` (development) — and, in production, before the SPA's default-page static file handler.
 3. Requests for URLs your MVC endpoints or static-file middleware already handle never reach the prerenderer.
 
-Before calling downstream, the middleware also strips the conditional-request headers (`If-Match`, `If-None-Match`, `If-Modified-Since`, `If-Unmodified-Since`, `If-Range`) and the `Accept-Encoding` header from the request, so the captured page is a full, uncompressed `200` body rather than a `304` or a gzip stream. `Accept-Encoding` is restored afterwards.
+Before calling downstream, the middleware strips the headers that would make the downstream answer with something other than the whole page: the conditional-request headers (`If-Match`, `If-None-Match`, `If-Modified-Since`, `If-Unmodified-Since`, `If-Range`), `Range`, and `Accept-Encoding`. Otherwise the capture could be a `304`, a `206` slice, or a gzip stream rather than a full `200` body.
+
+`Accept-Encoding` is restored after the capture, because upstream compression middleware reads it when the response starts. `Range` is not restored: nothing downstream of the capture reads it, and a prerendered body cannot satisfy a byte range in any case.
 
 A request is only prerendered when **all** of these hold:
 
+- the request method is `GET`;
 - its path does not start with any prefix in `ExcludeUrls`;
 - the client has not aborted the request;
-- the captured response status is `2xx`;
 - the captured `Content-Type` media type is `text/html` (matched case-insensitively, parameters such as `; charset=utf-8` ignored);
+- the captured response status is **exactly `200`**, and carries no `Content-Range` header;
+- the captured response is not content-encoded (no `Content-Encoding`, or `identity`);
+- if the response declared a `Content-Length`, that many bytes were actually captured;
+- the captured bytes are valid UTF-8, and the decoded template contains no NUL characters;
 - the captured body is not empty or whitespace;
 - `HttpContext.SkipPrerendering()` was not called for the request.
 
 Otherwise the captured bytes are copied through to the real response stream unchanged — so a JSON API response, a `404`, or a CSS file passes through untouched. Not being `text/html` is not an error; it is the normal path for static content in development.
+
+Everything after the content-type check is one requirement stated five ways: **the capture has to be the complete document.** Being `text/html` with a successful status does not establish that — a `Range: bytes=0-0` request makes the static-file middleware answer `206` with a single byte of `index.html`, which is `text/html` and 2xx and would otherwise have been used as the template. The middleware therefore strips `Range` from the request before capturing (alongside the conditional headers), and rejects a partial representation if one arrives anyway from a source it does not control, such as a dev-server proxy.
+
+### `GET` only
+
+Prerendering applies to `GET`. Other methods are passed straight through, before the server bundle is built, so a `POST` or `OPTIONS` to a SPA route does not wait for a build it has no use for.
+
+A `HEAD` is included in that: the static-file middleware answers a `HEAD` with the headers a `GET` would return and no body, so there is no template to render. Its `Content-Length` still reports the length of the document the equivalent `GET` would return, as it should.
 
 ## Basic setup
 
@@ -393,13 +407,14 @@ The same distinction applies at shutdown: a host that is stopping stops waiting 
 
 ## Logging
 
-The middleware logs under the category **`UseSpaPrerendering`**:
+The middleware logs under the category **`MintPlayer.AspNetCore.SpaServices.Prerendering.SpaPrerenderingExtensions`**, so it can be filtered by namespace like any other component.
 
 | Level | When |
 | --- | --- |
 | `Information` | Once, when the server boot module build starts (`"Building server BootModule"`). |
-| `Debug` | A request was skipped because the client aborted. Includes the request path, the number of bytes actually captured, and the `Content-Length` the downstream declared — the gap between the two is the diagnosis. |
-| `Warning` | A request was skipped because the captured template was empty or whitespace, so there was nothing to prerender. There is no known benign cause for this, so it is worth investigating. |
+| `Debug` | The request was not a `GET`, or its status carries no response body (`204`, `205`, `304`), or the client aborted. All three are benign, so none of them warns. The abort line includes the bytes actually captured against the `Content-Length` the downstream declared — the gap between the two is the diagnosis. |
+| `Warning` | The capture could not be used as a template: a partial representation (status other than `200`, or a `Content-Range` header — the line names the method, the status and the `Content-Range`), a `Content-Encoding` this middleware cannot undo, fewer bytes captured than declared, bytes that are not valid UTF-8, a decoded template containing NUL characters, or an empty template. Each of these means prerendering silently stopped happening for that request, which is why they are visible at default level. |
+| `Warning`, then `Debug` | The template has no `<html>` element. This is **not** a rejection — a fragment template is supported, and the render normally succeeds — but if prerendering is misbehaving it is the first thing to check. Warned once per pipeline and logged at `Debug` thereafter, so a deliberate fragment deployment does not warn on every request. Includes the first 200 characters of the template. |
 
 Your build script's own output is logged separately under the category **`AngularPrerendererBuilder`**.
 
@@ -411,7 +426,7 @@ To see the `Debug` messages, raise the level for that category in `appsettings.D
     "LogLevel": {
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning",
-      "UseSpaPrerendering": "Debug",
+      "MintPlayer.AspNetCore.SpaServices.Prerendering": "Debug",
       "AngularPrerendererBuilder": "Debug"
     }
   }
@@ -425,10 +440,10 @@ To see the `Debug` messages, raise the level for that category in `appsettings.D
 Angular was handed an empty or missing document. Check, in order:
 
 1. Your `main.server.ts` passes `params.data.originalHtml` as the `document` option — not `''`, not a hand-written string, not an omitted option.
-2. The response captured from the downstream pipeline is not empty. If it is, a `Warning` under the `UseSpaPrerendering` category names the path and the captured-versus-declared byte counts; enable the logging above.
+2. The response captured from the downstream pipeline is not empty. If it is, a `Warning` under the `MintPlayer.AspNetCore.SpaServices.Prerendering` category names the path and the captured-versus-declared byte counts; enable the logging above.
 3. In production, `SpaStaticFilesOptions.RootPath` points at the folder that actually contains `index.html`. Angular 17+ splits its output, so the browser assets sit in `dist/browser`, not `dist` — pointing at `dist` means there is no default page to capture.
 
-An aborted request no longer produces this: it is skipped, with a `Debug` message.
+An aborted request no longer produces this: it is skipped, with a `Debug` message. Neither does a `Range` request, a `HEAD`, or a response in a non-UTF-8 charset - see the conditions list above.
 
 ### The first request hangs, or the build never finishes
 
@@ -445,9 +460,12 @@ If the build legitimately takes longer than two minutes, raise `spa.Options.Star
 
 The response comes back as the unrendered shell, and no error appears. Work through the conditions the middleware requires:
 
+- **Request method** — must be `GET`. A `HEAD`, `POST` or `OPTIONS` is passed straight through.
 - **`ExcludeUrls`** — is the request path under one of the excluded prefixes?
 - **Content type** — the captured `Content-Type` media type must be `text/html`. A downstream that answers with `application/octet-stream`, or with no `Content-Type` at all, is passed through. (Matching is case-insensitive and ignores parameters, so `TEXT/HTML` and `text/html ; charset=utf-8` both qualify.)
-- **Status code** — must be `2xx`. A `304`, a `404` or a redirect is passed through. Conditional-request headers are stripped precisely so a `304` is not what gets captured.
+- **Status code** — must be exactly `200`. A `304`, a `404`, a redirect or a `206 Partial Content` is passed through. Conditional-request headers and `Range` are stripped precisely so a `304` or a `206` is not what gets captured.
+- **Partial or encoded capture** — a response carrying `Content-Range`, a `Content-Encoding` other than `identity`, or fewer bytes than its own `Content-Length` declared, is skipped with a `Warning`. Each of these means the capture is not the whole document.
+- **Not valid UTF-8** — the template is decoded as UTF-8 regardless of the declared charset, so a response in another charset (`text/html; charset=utf-16`, say) is skipped with a `Warning`.
 - **Empty body** — an empty captured template is skipped with a `Warning`.
 - **`SkipPrerendering()`** — did your own code, or `ISpaRouteService.Redirect`, opt this request out?
 - **Pipeline order** — is `UseSpaPrerendering` registered before the middleware that serves the page (the CLI server in development, the static-file default page in production)? Registered after, it never sees a template.
@@ -456,6 +474,27 @@ The response comes back as the unrendered shell, and no error appears. Work thro
 ### A redirect returns a prerendered page body
 
 The redirect's status was assigned from a `Response.OnStarting` callback, which the middleware cannot see, so the page was prerendered and the render's output collided with the redirect. Call `HttpContext.SkipPrerendering()` alongside the redirect — or use `ISpaRouteService.Redirect`, which already does.
+
+### An error page gets prerendered instead of your app
+
+If `UseExceptionHandler`, `UseStatusCodePagesWithReExecute` or similar is registered **inside** the `UseSpaImproved` callback, it sits inside the capture — so when it handles a downstream failure, its error page becomes what this middleware captures and hands to the renderer. That page is a complete, well-formed `text/html` document, so it passes every check the middleware makes; the render then fails with `NG05104` because the page contains no application root element.
+
+Register error handling **outside** the SPA callback, near the top of `Configure`, as in the Basic setup above. If you need a template assertion that is specific to your app, the place for it is your own `OnSupplyData`:
+
+```csharp
+public Task OnSupplyData(HttpContext httpContext, IDictionary<string, object> data)
+{
+    var template = (string)data["originalHtml"];
+
+    // The middleware cannot check this: it does not know your root element's name.
+    if (!template.Contains("<my-app", StringComparison.Ordinal))
+    {
+        throw new InvalidOperationException("The SSR template has no application root element.");
+    }
+
+    return Task.CompletedTask;
+}
+```
 
 ### `Globals is not supported when prerendering via UseSpaPrerendering()`
 

--- a/MintPlayer.AspNetCore.SpaServices.Prerendering/README.md
+++ b/MintPlayer.AspNetCore.SpaServices.Prerendering/README.md
@@ -51,6 +51,8 @@ Otherwise the captured bytes are copied through to the real response stream unch
 
 Everything after the content-type check is one requirement stated five ways: **the capture has to be the complete document.** Being `text/html` with a successful status does not establish that — a `Range: bytes=0-0` request makes the static-file middleware answer `206` with a single byte of `index.html`, which is `text/html` and 2xx and would otherwise have been used as the template. The middleware therefore strips `Range` from the request before capturing (alongside the conditional headers), and rejects a partial representation if one arrives anyway from a source it does not control, such as a dev-server proxy.
 
+One consequence worth knowing: because the header is removed before the downstream sees it, a `Range` request is answered with the whole prerendered page rather than a slice, and an *unsatisfiable* range no longer produces a `416` either. A server is permitted to ignore `Range`, and a prerendered body — generated per request — has no stable byte range to serve.
+
 ### `GET` only
 
 Prerendering applies to `GET`. Other methods are passed straight through, before the server bundle is built, so a `POST` or `OPTIONS` to a SPA route does not wait for a build it has no use for.
@@ -414,7 +416,7 @@ The middleware logs under the category **`MintPlayer.AspNetCore.SpaServices.Prer
 | `Information` | Once, when the server boot module build starts (`"Building server BootModule"`). |
 | `Debug` | The request was not a `GET`, or its status carries no response body (`204`, `205`, `304`), or the client aborted. All three are benign, so none of them warns. The abort line includes the bytes actually captured against the `Content-Length` the downstream declared — the gap between the two is the diagnosis. |
 | `Warning` | The capture could not be used as a template: a partial representation (status other than `200`, or a `Content-Range` header — the line names the method, the status and the `Content-Range`), a `Content-Encoding` this middleware cannot undo, fewer bytes captured than declared, bytes that are not valid UTF-8, a decoded template containing NUL characters, or an empty template. Each of these means prerendering silently stopped happening for that request, which is why they are visible at default level. |
-| `Warning`, then `Debug` | The template has no `<html>` element. This is **not** a rejection — a fragment template is supported, and the render normally succeeds — but if prerendering is misbehaving it is the first thing to check. Warned once per pipeline and logged at `Debug` thereafter, so a deliberate fragment deployment does not warn on every request. Includes the first 200 characters of the template. |
+| `Warning`, then `Debug` | The template has no `<html>` opening tag. This is **not** a rejection — a fragment template is supported, and the render normally succeeds — but if prerendering is misbehaving it is the first thing to check. Warned once per pipeline and logged at `Debug` thereafter, so a deliberate fragment deployment does not warn on every request. Includes the first 200 characters of the template. |
 
 Your build script's own output is logged separately under the category **`AngularPrerendererBuilder`**.
 

--- a/MintPlayer.AspNetCore.SpaServices.Routing/MintPlayer.AspNetCore.SpaServices.Routing.csproj
+++ b/MintPlayer.AspNetCore.SpaServices.Routing/MintPlayer.AspNetCore.SpaServices.Routing.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices.Routing</PackageId>
-		<Version>10.7.0</Version>
+		<Version>10.7.1</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingExtensionsTests.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingExtensionsTests.cs
@@ -49,7 +49,11 @@ internal static class PrerenderingTestContext
     public static DefaultHttpContext Create(string? rawTarget = null, MemoryStream? responseBody = null)
     {
         var features = new FeatureCollection();
-        features.Set<IHttpRequestFeature>(new HttpRequestFeature { RawTarget = rawTarget! });
+
+        // HttpRequestFeature.Method defaults to string.Empty, which is not GET - and the
+        // prerendering middleware only prerenders GET requests, so without this every test would
+        // short-circuit before reaching the code under test.
+        features.Set<IHttpRequestFeature>(new HttpRequestFeature { RawTarget = rawTarget!, Method = HttpMethods.Get });
         features.Set<IHttpResponseFeature>(new HttpResponseFeature());
 
         // A response body feature is always required: HttpResponse.Clear() reads Response.Body,
@@ -143,6 +147,10 @@ public class RemoveConditionalRequestHeadersTests
         headers[HeaderNames.IfNoneMatch] = "\"etag\"";
         headers[HeaderNames.IfUnmodifiedSince] = "Wed, 21 Oct 2015 07:28:00 GMT";
         headers[HeaderNames.IfRange] = "\"etag\"";
+
+        // Range goes with them: the capture has to be the whole document, and a Range request makes
+        // StaticFileMiddleware answer 206 with a slice of it (issue #80).
+        headers[HeaderNames.Range] = "bytes=0-0";
         headers[HeaderNames.Accept] = "text/html";
 
         SpaPrerenderingReflection.RemoveConditionalRequestHeaders(context.Request);
@@ -152,6 +160,7 @@ public class RemoveConditionalRequestHeadersTests
         Assert.False(headers.ContainsKey(HeaderNames.IfNoneMatch));
         Assert.False(headers.ContainsKey(HeaderNames.IfUnmodifiedSince));
         Assert.False(headers.ContainsKey(HeaderNames.IfRange));
+        Assert.False(headers.ContainsKey(HeaderNames.Range));
         Assert.Equal("text/html", headers[HeaderNames.Accept].ToString());
     }
 

--- a/MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs
@@ -5,6 +5,8 @@ using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Net.Http.Headers;
 using MintPlayer.AspNetCore.NodeServices;
 using MintPlayer.AspNetCore.SpaServices.Prerendering;
 using MintPlayer.AspNetCore.SpaServices.Prerendering.Services;
@@ -144,15 +146,80 @@ internal static class PrerenderingHarness
         }
     }
 
+    /// <summary>One log line, as the middleware rendered it.</summary>
+    internal sealed record LogEntry(LogLevel Level, EventId EventId, string Message);
+
+    /// <summary>
+    /// Collects every log line the middleware writes, so that a diagnostic-only decision (warn once
+    /// about a fragment template, do not warn at all for a HEAD) is assertable.
+    /// </summary>
+    /// <remarks>
+    /// The harness registers no <see cref="ILoggerFactory"/> by default, so
+    /// <c>LoggerFinder.GetOrCreateLogger</c> hands the middleware <c>NullLogger.Instance</c> and no
+    /// log assertion is possible. This provider is registered in the *application* services before
+    /// <c>UseSpaPrerendering</c>, because the logger is resolved once at registration time rather
+    /// than per request. Nothing but the framework reference is needed for it - deliberately no
+    /// dependency on Microsoft.Extensions.Diagnostics.Testing / FakeLogger.
+    /// </remarks>
+    internal sealed class CollectingLoggerProvider : ILoggerProvider
+    {
+        public List<LogEntry> Entries { get; } = [];
+
+        public ILogger CreateLogger(string categoryName) => new CollectingLogger(this);
+
+        public void Dispose() { }
+
+        private sealed class CollectingLogger(CollectingLoggerProvider provider) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            // Unconditionally enabled: the LoggerFilterOptions default MinLevel is Information, and
+            // the lines under test here are Debug.
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+            {
+                lock (provider.Entries)
+                {
+                    provider.Entries.Add(new LogEntry(logLevel, eventId, formatter(state, exception)));
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// An <see cref="Abstractions.ISpaPrerendererBuilder"/> that counts builds instead of running one.
+    /// </summary>
+    /// <remarks>
+    /// Returns a completed task rather than one that never completes: asserting on a count fails the
+    /// test, whereas a never-completing task would hang the whole run.
+    /// </remarks>
+    internal sealed class RecordingBootModuleBuilder : Abstractions.ISpaPrerendererBuilder
+    {
+        private int _buildCount;
+
+        public int BuildCount => Volatile.Read(ref _buildCount);
+
+        public Task Build(Abstractions.ISpaBuilder spaBuilder)
+        {
+            Interlocked.Increment(ref _buildCount);
+            return Task.CompletedTask;
+        }
+    }
+
     internal sealed record Result(
         RecordingPrerenderingService Service,
         DefaultHttpContext Context,
         MemoryStream ClientBody,
-        RecordingNodeServices? NodeServices);
+        RecordingNodeServices? NodeServices,
+        IReadOnlyList<LogEntry> Logs);
 
     /// <summary>
     /// Builds the real middleware pipeline (prerendering middleware + a fake inner pipeline) and
-    /// runs one request through it.
+    /// runs one request through it - or <paramref name="requestCount"/> requests through the *same*
+    /// pipeline, which is what a per-pipeline latch (the structural warning) has to be tested
+    /// against. The returned <see cref="Result"/> is the last request's; <see cref="Result.Logs"/>
+    /// spans all of them, because the collecting provider belongs to the pipeline.
     /// </summary>
     public static async Task<Result> Run(
         RequestDelegate innerPipeline,
@@ -161,7 +228,10 @@ internal static class PrerenderingHarness
         Action<DefaultHttpContext>? configureContext = null,
         RecordingNodeServices? recordingNodeServices = null,
         int statusCodeFromOnSupplyData = StatusCodes.Status302Found,
-        HarnessApplicationLifetime? lifetime = null)
+        HarnessApplicationLifetime? lifetime = null,
+        Action<SpaPrerenderingOptions>? configureOptions = null,
+        bool collectLogs = false,
+        int requestCount = 1)
     {
         var service = new RecordingPrerenderingService { StatusCodeToSet = statusCodeFromOnSupplyData };
 
@@ -175,6 +245,16 @@ internal static class PrerenderingHarness
             services.AddSingleton<INodeServices>(new ExplodingNodeServices());
         }
 
+        var logProvider = new CollectingLoggerProvider();
+        if (collectLogs)
+        {
+            // MinLevel has to be lowered explicitly: LoggerFilterOptions defaults to Information,
+            // which would drop the Debug lines these tests assert on before they reach the provider.
+            services.AddSingleton<ILoggerFactory>(new LoggerFactory(
+                [logProvider],
+                new LoggerFilterOptions { MinLevel = LogLevel.Trace }));
+        }
+
         var applicationServices = services
             .AddSingleton<IWebHostEnvironment>(new HarnessWebHostEnvironment())
             .AddSingleton<IHostApplicationLifetime>(lifetime ?? new HarnessApplicationLifetime())
@@ -184,8 +264,12 @@ internal static class PrerenderingHarness
         var spaBuilder = new HarnessSpaBuilder(applicationBuilder, new Core.SpaOptions());
 
         // Registers the middleware under test, and resolves INodeServices / IHostApplicationLifetime /
-        // IWebHostEnvironment eagerly right here.
-        spaBuilder.UseSpaPrerendering(options => options.BootModulePath = "dist/server/main.js");
+        // IWebHostEnvironment / ILoggerFactory eagerly right here.
+        spaBuilder.UseSpaPrerendering(options =>
+        {
+            options.BootModulePath = "dist/server/main.js";
+            configureOptions?.Invoke(options);
+        });
 
         // The inner "next" is ours. Registered after, so next() lands on it instead of on
         // ApplicationBuilder's default 404 terminal.
@@ -193,19 +277,25 @@ internal static class PrerenderingHarness
 
         var pipeline = applicationBuilder.Build();
 
-        var clientBody = new MemoryStream();
-        var context = PrerenderingTestContext.Create(rawTarget, clientBody);
-        context.Request.Scheme = "https";
-        context.Request.Host = new HostString("localhost", 5001);
-        context.RequestServices = new ServiceCollection()
-            .AddSingleton<ISpaPrerenderingService>(service)
-            .BuildServiceProvider();
+        Result? result = null;
+        for (var i = 0; i < requestCount; i++)
+        {
+            var clientBody = new MemoryStream();
+            var context = PrerenderingTestContext.Create(rawTarget, clientBody);
+            context.Request.Scheme = "https";
+            context.Request.Host = new HostString("localhost", 5001);
+            context.RequestServices = new ServiceCollection()
+                .AddSingleton<ISpaPrerenderingService>(service)
+                .BuildServiceProvider();
 
-        configureContext?.Invoke(context);
+            configureContext?.Invoke(context);
 
-        await pipeline(context);
+            await pipeline(context);
 
-        return new Result(service, context, clientBody, recordingNodeServices);
+            result = new Result(service, context, clientBody, recordingNodeServices, logProvider.Entries);
+        }
+
+        return result!;
     }
 
     /// <summary>An inner pipeline that answers 200 text/html with the given body in one write.</summary>
@@ -252,10 +342,62 @@ internal static class PrerenderingHarness
         return Task.CompletedTask;
     };
 
+    /// <summary>
+    /// An inner pipeline that mimics what StaticFileMiddleware leaves behind for a HEAD request:
+    /// status, Content-Type and the *full* Content-Length of the file, and no body at all.
+    /// </summary>
+    /// <remarks>
+    /// Byte-identical in effect to <see cref="AbortedStaticFile"/>, and deliberately a separate
+    /// name: the two model different contracts (a HEAD that must report the length the equivalent
+    /// GET would, versus an abort whose declared length is now a lie), and conflating them is how a
+    /// fix for one silently changes the other.
+    /// </remarks>
+    public static RequestDelegate StaticFileHead(long declaredLength) => context =>
+    {
+        context.Response.StatusCode = StatusCodes.Status200OK;
+        context.Response.ContentType = "text/html";
+        context.Response.ContentLength = declaredLength;
+
+        return Task.CompletedTask;
+    };
+
+    /// <summary>
+    /// An inner pipeline that answers a satisfiable single-range request the way
+    /// StaticFileMiddleware does: 206, the file's own Content-Type, a Content-Range, Accept-Ranges,
+    /// and only the requested bytes in the body.
+    /// </summary>
+    /// <remarks>
+    /// <c>ContentLength</c> is the *slice* length, faithfully - which is why the declared-versus-
+    /// captured check cannot catch issue #80, and the status/Content-Range framing checks must.
+    /// </remarks>
+    public static RequestDelegate PartialContent(byte[] slice, long from, long to, long total)
+        => async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status206PartialContent;
+            context.Response.ContentType = "text/html";
+            context.Response.ContentLength = slice.Length;
+            context.Response.Headers[HeaderNames.ContentRange] = $"bytes {from}-{to}/{total}";
+            context.Response.Headers[HeaderNames.AcceptRanges] = "bytes";
+            await context.Response.Body.WriteAsync(slice);
+        };
+
     /// <summary>Builds an HTML page of exactly <paramref name="totalBytes"/> UTF-8 bytes.</summary>
     public static string HtmlOfSize(int totalBytes)
     {
         const string prefix = "<html><body><app-root></app-root><!--";
+        const string suffix = "--></body></html>";
+        var filler = totalBytes - prefix.Length - suffix.Length;
+        Assert.True(filler >= 0, "requested size is smaller than the surrounding markup");
+        return prefix + new string('x', filler) + suffix;
+    }
+
+    /// <summary>
+    /// An HTML page of exactly <paramref name="totalBytes"/> UTF-8 bytes that opens the way a real
+    /// <c>ng build</c> index.html does, so that a leading slice of it looks exactly like markup.
+    /// </summary>
+    public static string DoctypeHtmlOfSize(int totalBytes)
+    {
+        const string prefix = "<!doctype html><html lang=\"en\"><head><title>demo</title></head><body><app-root></app-root><!--";
         const string suffix = "--></body></html>";
         var filler = totalBytes - prefix.Length - suffix.Length;
         Assert.True(filler >= 0, "requested size is smaller than the surrounding markup");
@@ -505,10 +647,17 @@ public class AbortedRequestTests
     [Fact]
     public async Task Still_prerenders_a_partially_captured_template()
     {
-        // Deliberate, and the reason the abort check is not redundant with the empty-template guard:
-        // an abort mid-copy leaves a truncated body, which is non-empty and so passes the guard.
-        // Only the abort check catches that case, so this documents the division of labour rather
-        // than asserting the truncation is acceptable.
+        // Deliberate, and the reason the abort check is not redundant with the other guards: a
+        // truncated body is non-empty, so the empty-template guard passes it.
+        //
+        // Note the division of labour has narrowed. The declared-versus-captured check now catches a
+        // partial capture too - see
+        // RangeAndTemplateValidityTests.Does_not_prerender_a_capture_shorter_than_its_declared_content_length -
+        // so the abort check is the only remaining cover for a *chunked* partial: no ContentLength
+        // was declared (HtmlPageInChunks declares the sum of the chunks it actually writes, so
+        // captured == declared here and the length check is silent), and nothing at this layer can
+        // tell a short capture from a short page. This test asserts the current division of labour,
+        // not that the truncation is acceptable.
         var result = await PrerenderingHarness.Run(PrerenderingHarness.HtmlPageInChunks(
             Encoding.UTF8.GetBytes("<html><body><app-r")));
 
@@ -551,6 +700,699 @@ public class AbortedRequestTests
 
         Assert.True(result.Service.WasCalled);
         Assert.Equal(html, Encoding.UTF8.GetString(result.ClientBody.ToArray()));
+    }
+}
+
+/// <summary>
+/// Issue #80 and its class: the capture has to be a *complete, decodable representation*, not
+/// merely a 2xx text/html one. Grown out of the scratch reproduction in the investigation, with the
+/// assertions inverted now that the middleware rejects those captures.
+/// </summary>
+public class RangeAndTemplateValidityTests
+{
+    private const string IndexHtml =
+        "<!doctype html><html><head><title>demo</title></head><body><app-root></app-root></body></html>";
+
+    private static Action<DefaultHttpContext> WithRange(string value)
+        => context => context.Request.Headers[HeaderNames.Range] = value;
+
+    // ---------------------------------------------------------------------------------------------
+    // Framing: partial content
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Does_not_prerender_a_single_byte_partial_response()
+    {
+        // The reported symptom, inverted: `Range: bytes=0-0` made static files answer 206 with the
+        // single "<" of "<!doctype html>", and that one byte was handed to the prerenderer as the
+        // SSR template. The framing headers are deliberately left intact on the way out - rejecting
+        // the template is not a reason to rewrite a correct 206.
+        var html = PrerenderingHarness.HtmlOfSize(547);
+        var bytes = Encoding.UTF8.GetBytes(html);
+
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.PartialContent(bytes[..1], 0, 0, bytes.Length),
+            rawTarget: "/person",
+            configureContext: WithRange("bytes=0-0"));
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(bytes[..1], result.ClientBody.ToArray());
+        Assert.Equal(StatusCodes.Status206PartialContent, result.Context.Response.StatusCode);
+        Assert.Equal("bytes 0-0/547", result.Context.Response.Headers[HeaderNames.ContentRange].ToString());
+        Assert.Equal(1, result.Context.Response.ContentLength);
+    }
+
+    [Fact]
+    public async Task Does_not_prerender_a_markup_shaped_partial_slice()
+    {
+        // Load-bearing, and not a duplicate of the single-byte case: a 100-byte leading slice of a
+        // real index.html *is* well-formed-looking markup, which is why no amount of "does the
+        // template look plausible" checking can stand in for the framing check. The first assertion
+        // is the one that records that; delete it and this test reads as redundant.
+        var html = PrerenderingHarness.DoctypeHtmlOfSize(20_000);
+        var bytes = Encoding.UTF8.GetBytes(html);
+        var slice = Encoding.UTF8.GetString(bytes[..100]);
+
+        Assert.StartsWith("<!doctype html><html lang=\"en\">", slice);
+
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.PartialContent(bytes[..100], 0, 99, bytes.Length),
+            rawTarget: "/person",
+            configureContext: WithRange("bytes=0-99"));
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(bytes[..100], result.ClientBody.ToArray());
+    }
+
+    [Fact]
+    public async Task Does_not_prerender_a_mid_document_partial_slice()
+    {
+        // The other end of the same shape: a slice from the middle of the document, with no "<html"
+        // in it at all.
+        var html = PrerenderingHarness.DoctypeHtmlOfSize(20_000);
+        var bytes = Encoding.UTF8.GetBytes(html);
+        var slice = Encoding.UTF8.GetString(bytes[100..201]);
+
+        Assert.DoesNotContain("<html", slice, StringComparison.OrdinalIgnoreCase);
+
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.PartialContent(bytes[100..201], 100, 200, bytes.Length),
+            rawTarget: "/person",
+            configureContext: WithRange("bytes=100-200"));
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(bytes[100..201], result.ClientBody.ToArray());
+    }
+
+    [Fact]
+    public async Task Does_not_prerender_a_two_hundred_that_still_carries_a_content_range()
+    {
+        // Pins the Content-Range check independently of the status check: a middleware that rewrites
+        // a 206 to a 200 without dropping the framing header would otherwise slip a partial
+        // representation past a status-only gate.
+        var result = await PrerenderingHarness.Run(
+            async context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status200OK;
+                context.Response.ContentType = "text/html";
+                context.Response.Headers[HeaderNames.ContentRange] = "bytes 0-94/95";
+                var bytes = Encoding.UTF8.GetBytes(IndexHtml);
+                context.Response.ContentLength = bytes.Length;
+                await context.Response.Body.WriteAsync(bytes);
+            },
+            rawTarget: "/person");
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, Encoding.UTF8.GetString(result.ClientBody.ToArray()));
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Status201Created)]
+    [InlineData(StatusCodes.Status202Accepted)]
+    [InlineData(StatusCodes.Status203NonAuthoritative)]
+    [InlineData(StatusCodes.Status226IMUsed)]
+    public async Task Does_not_prerender_any_other_success_status(int statusCode)
+    {
+        // The status check is "exactly 200", not "2xx minus the ones we know about", so it fails
+        // closed on statuses nobody has considered. 203 in particular is by definition a *modified*
+        // representation - the same class of bug as a 206 - and 226 is a delta encoding, which is a
+        // diff rather than a document. Pinned so a future widening back to IsSuccessStatusCode
+        // cannot happen quietly.
+        var result = await PrerenderingHarness.Run(
+            async context =>
+            {
+                context.Response.StatusCode = statusCode;
+                context.Response.ContentType = "text/html";
+                var bytes = Encoding.UTF8.GetBytes(IndexHtml);
+                context.Response.ContentLength = bytes.Length;
+                await context.Response.Body.WriteAsync(bytes);
+            },
+            rawTarget: "/person");
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, Encoding.UTF8.GetString(result.ClientBody.ToArray()));
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Request-side strip
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Strips_the_range_header_before_the_capture()
+    {
+        // The cause, fixed at the source: with Range gone, static files never computes a range and
+        // answers 200 with the whole file. If-Range has to go too - and did before - because
+        // StaticFileContext.ComputeIfRange is the only code that can cancel an already-parsed
+        // range, so removing only If-Range guaranteed the range was always honoured.
+        var sawRange = true;
+        var sawIfRange = true;
+
+        await PrerenderingHarness.Run(
+            context =>
+            {
+                sawRange = context.Request.Headers.ContainsKey(HeaderNames.Range);
+                sawIfRange = context.Request.Headers.ContainsKey(HeaderNames.IfRange);
+                context.Response.StatusCode = StatusCodes.Status200OK;
+                context.Response.ContentType = "text/html";
+                return Task.CompletedTask;
+            },
+            rawTarget: "/person",
+            configureContext: context =>
+            {
+                context.Request.Headers[HeaderNames.Range] = "bytes=0-0";
+                context.Request.Headers[HeaderNames.IfRange] = "\"etag\"";
+            });
+
+        Assert.False(sawRange);
+        Assert.False(sawIfRange);
+    }
+
+    [Fact]
+    public async Task Does_not_restore_the_range_header_after_the_capture()
+    {
+        // Both halves of the asymmetry in one test, because the asymmetry *is* the decision:
+        // Accept-Encoding must come back (upstream compression middleware reads it when the
+        // prerendered body is written), Range must not (nothing downstream of the capture reads it,
+        // and a prerendered body cannot satisfy a byte range anyway). A test asserting only one
+        // half invites the other to be "symmetrised" back in.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            rawTarget: "/person",
+            configureContext: context =>
+            {
+                context.Request.Headers[HeaderNames.Range] = "bytes=0-0";
+                context.Request.Headers[HeaderNames.AcceptEncoding] = "gzip, br";
+            });
+
+        Assert.False(result.Context.Request.Headers.ContainsKey(HeaderNames.Range));
+        Assert.Equal("gzip, br", result.Context.Request.Headers[HeaderNames.AcceptEncoding].ToString());
+    }
+
+    [Fact]
+    public async Task Prerenders_normally_when_a_range_request_is_answered_with_a_full_two_hundred()
+    {
+        // Control: the header alone is harmless. Whatever serves the page may ignore ranges (the
+        // dev-server proxy does), and then the template is complete and prerendering is correct.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            rawTarget: "/person",
+            configureContext: WithRange("bytes=0-0"));
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Controls that a status-check change must not break
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Does_not_prerender_an_unsatisfiable_range_response()
+    {
+        // Control. Passed before the fix through IsSuccessStatusCode and passes now through the
+        // exactly-200 check. Its point is that a future "let's accept any 2xx again" change cannot
+        // quietly start accepting a 416.
+        var result = await PrerenderingHarness.Run(
+            context =>
+            {
+                context.Response.StatusCode = StatusCodes.Status416RangeNotSatisfiable;
+                context.Response.ContentType = "text/html";
+                context.Response.Headers[HeaderNames.ContentRange] = "bytes */547";
+                return Task.CompletedTask;
+            },
+            rawTarget: "/person",
+            configureContext: WithRange("bytes=999999-"));
+
+        Assert.False(result.Service.WasCalled);
+    }
+
+    [Fact]
+    public async Task Prerenders_a_multi_range_request_that_downstream_ignored()
+    {
+        // Control, observed against the real app: StaticFileMiddleware does not implement
+        // multipart/byteranges, so more than one range makes it ignore the header entirely and
+        // answer 200 with the whole file.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            rawTarget: "/person",
+            configureContext: WithRange("bytes=0-0,2-2"));
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+    }
+
+    [Theory]
+    [InlineData("bananas=1-2")]
+    [InlineData("bytes=abc")]
+    [InlineData("items=0-0")]
+    public async Task Prerenders_a_malformed_range_request_that_downstream_ignored(string range)
+    {
+        // Control. ASP.NET Core ignores all three, so the response is a full 200. The unit row
+        // ("items=0-0") is here rather than in a comment because neither RangeHelper.ParseRange nor
+        // RangeHeaderValue validates the range *unit* - the unit is checked by StaticFileContext
+        // separately, and a check that trusted the header's shape would be wrong about it.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            rawTarget: "/person",
+            configureContext: WithRange(range));
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Content-Encoding
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Does_not_prerender_a_capture_with_a_content_encoding()
+    {
+        // Accept-Encoding is stripped from the request so that the capture is plain text, but
+        // nothing verified the result. A still-encoded capture would be decoded as UTF-8 and hand
+        // the prerenderer compressed bytes.
+        var compressed = new byte[] { 0x1b, 0x2e, 0x00, 0xf8, 0x25, 0x84, 0xcf, 0xd1, 0xff, 0x9c };
+
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html";
+            context.Response.Headers[HeaderNames.ContentEncoding] = "br";
+            context.Response.ContentLength = compressed.Length;
+            await context.Response.Body.WriteAsync(compressed);
+        });
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(compressed, result.ClientBody.ToArray());
+    }
+
+    [Theory]
+    [InlineData("identity")]
+    [InlineData("IDENTITY")]
+    public async Task Prerenders_a_capture_that_declares_identity_encoding(string encoding)
+    {
+        // Guards the encoding check against over-firing: `identity` means no coding was applied, and
+        // content codings are case-insensitive.
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html";
+            context.Response.Headers[HeaderNames.ContentEncoding] = encoding;
+            var bytes = Encoding.UTF8.GetBytes(IndexHtml);
+            context.Response.ContentLength = bytes.Length;
+            await context.Response.Body.WriteAsync(bytes);
+        });
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Decode integrity
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Does_not_prerender_a_capture_that_is_not_valid_utf8()
+    {
+        // A compressed capture that arrives with no Content-Encoding header at all - the second net
+        // under the encoding check - and equally a genuinely corrupt body. 0xC3 starts a two-byte
+        // sequence that never completes, so the bytes are not valid UTF-8 however much real markup
+        // surrounds them.
+        var body = Encoding.UTF8.GetBytes("<html><body>")
+            .Concat(new byte[] { 0xC3 })
+            .Concat(Encoding.UTF8.GetBytes("</body></html>"))
+            .ToArray();
+
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html";
+            context.Response.ContentLength = body.Length;
+            await context.Response.Body.WriteAsync(body);
+        });
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(body, result.ClientBody.ToArray());
+    }
+
+    [Fact]
+    public async Task Does_not_prerender_a_utf16_encoded_template()
+    {
+        // UTF-16 markup is byte-wise *valid* UTF-8 - every ASCII character becomes a byte pair whose
+        // second byte is 0x00 - so it decodes to "<\0!\0d\0..." and reaches the prerenderer as
+        // NG05104. Note char.IsWhiteSpace('\0') is false, which is why the empty-template guard
+        // never caught it and an explicit NUL check is needed.
+        Assert.False(char.IsWhiteSpace('\0'));
+
+        var body = Encoding.Unicode.GetBytes(IndexHtml);
+
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html; charset=utf-16";
+            context.Response.ContentLength = body.Length;
+            await context.Response.Body.WriteAsync(body);
+        });
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(body, result.ClientBody.ToArray());
+    }
+
+    [Fact]
+    public async Task Prerenders_a_template_containing_a_literal_replacement_character()
+    {
+        // Pins the choice of validating the *bytes* with Utf8.IsValid over scanning the decoded
+        // string for U+FFFD. A replacement character is legitimate page content, and rejecting it
+        // would turn a working deployment off. Without this test the byte check looks like an
+        // over-complicated way to spell Contains('�').
+        var html = "<!doctype html><html><body><app-root></app-root><p>�</p></body></html>";
+
+        var result = await PrerenderingHarness.Run(PrerenderingHarness.HtmlPage(html));
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(html, result.Service.OriginalHtml);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Declared versus captured
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Does_not_prerender_a_capture_shorter_than_its_declared_content_length()
+    {
+        // A short capture against a declared length means the body was truncated or never flushed,
+        // whatever the status says - and unlike the abort check this needs no abort to fire, which
+        // covers an unflushed PipeWriter write and a body send that failed silently.
+        //
+        // This deliberately reverses SOLUTION-defect2-abort.md section 2, whose premise was that a
+        // transformer might legitimately leave a stale Content-Length. It cannot: Kestrel's own
+        // Content-Length verification would already fail every such response on every route this
+        // middleware never touches. See Prerenders_a_response_a_transforming_middleware_shrank for
+        // the shape that premise was really about.
+        var html = PrerenderingHarness.HtmlOfSize(20_000);
+        var bytes = Encoding.UTF8.GetBytes(html);
+
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html";
+            context.Response.ContentLength = 20_000;
+            await context.Response.Body.WriteAsync(bytes[..8192]);
+        });
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(bytes[..8192], result.ClientBody.ToArray());
+    }
+
+    [Fact]
+    public async Task Prerenders_a_response_a_transforming_middleware_shrank()
+    {
+        // The regression guard for the declared-versus-captured decision, modelled on
+        // UseWebMarkupMin: it substitutes the response body, lets the inner pipeline declare and
+        // write the full page, then writes the minified page and *updates* ContentLength to match.
+        // Captured then equals declared and the length check is silent. If that check ever has to be
+        // removed, this is the test that will have failed.
+        var full = PrerenderingHarness.HtmlOfSize(547);
+        var minified = PrerenderingHarness.HtmlOfSize(456);
+        var minifiedBytes = Encoding.UTF8.GetBytes(minified);
+
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            var writeFullPage = PrerenderingHarness.HtmlPage(full);
+
+            var clientStream = context.Response.Body;
+            using var transformBuffer = new MemoryStream();
+            context.Response.Body = transformBuffer;
+            try
+            {
+                await writeFullPage(context);
+            }
+            finally
+            {
+                context.Response.Body = clientStream;
+            }
+
+            Assert.Equal(547, transformBuffer.Length);
+            Assert.Equal(547, context.Response.ContentLength);
+
+            context.Response.ContentLength = minifiedBytes.Length;
+            await context.Response.Body.WriteAsync(minifiedBytes);
+        });
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(minified, result.Service.OriginalHtml);
+        Assert.Equal(456, result.Service.OriginalHtml!.Length);
+    }
+
+    [Fact]
+    public async Task Prerenders_a_short_chunked_capture_with_no_declared_length()
+    {
+        // The length check makes no claim without a declared length, and must not invent one: on a
+        // chunked response nothing at this layer can tell a short capture from a short page.
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html";
+            await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(IndexHtml));
+        });
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+        Assert.Null(result.Context.Response.ContentLength);
+    }
+
+    [Fact]
+    public async Task Prerenders_a_capture_longer_than_its_declared_content_length()
+    {
+        // Pins the check's one-directionality. A capture *longer* than the declared length cannot be
+        // a truncation, so it is not this check's business. "Reject on any mismatch" is the obvious
+        // simplification, and this records that it was declined.
+        var result = await PrerenderingHarness.Run(async context =>
+        {
+            context.Response.StatusCode = StatusCodes.Status200OK;
+            context.Response.ContentType = "text/html";
+            context.Response.ContentLength = 10;
+            await context.Response.Body.WriteAsync(Encoding.UTF8.GetBytes(IndexHtml));
+        });
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Structural warning
+    // ---------------------------------------------------------------------------------------------
+
+    [Fact]
+    public async Task Prerenders_a_fragment_template_without_an_html_element()
+    {
+        // A fragment template is a legitimate if unusual deployment - the renderer normalizes a bare
+        // <app-root></app-root> into a full document - so the structural check logs and never
+        // rejects. Rejecting here would break a working application.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage("<app-root></app-root>"),
+            collectLogs: true);
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal("<app-root></app-root>", result.Service.OriginalHtml);
+
+        var warning = Assert.Single(result.Logs, e => e.Level == LogLevel.Warning);
+        Assert.Contains("no <html> element", warning.Message);
+    }
+
+    [Fact]
+    public async Task Warns_once_about_a_fragment_template_and_then_stays_quiet()
+    {
+        // Two requests through the *same* pipeline. A fragment deployment must not emit a warning
+        // per request forever, but a consumer whose template is silently wrong needs to see
+        // something at default level at least once - so the first is a Warning and every later one
+        // is the same message at Debug.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage("<app-root></app-root>"),
+            collectLogs: true,
+            requestCount: 2);
+
+        var structural = result.Logs.Where(e => e.Message.Contains("no <html> element")).ToList();
+
+        Assert.Equal(2, structural.Count);
+        Assert.Single(structural, e => e.Level == LogLevel.Warning);
+        Assert.Single(structural, e => e.Level == LogLevel.Debug);
+
+        // The latch is scoped to the UseSpaPrerendering call, not static, so a second pipeline gets
+        // its own Warning. That is the right lifetime: a process hosting two SPAs must hear about
+        // both.
+        var second = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage("<app-root></app-root>"),
+            collectLogs: true);
+
+        Assert.Single(second.Logs, e => e.Level == LogLevel.Warning);
+    }
+}
+
+/// <summary>
+/// Prerendering applies to GET only. Before the gate a HEAD entered the capture, blocked on the SSR
+/// bundle build, logged a warning about the (correctly) empty template, and had its
+/// <c>Content-Length</c> rewritten to 0 - a 200 text/html claiming zero bytes.
+/// </summary>
+public class RequestMethodGateTests
+{
+    private const string IndexHtml =
+        "<!doctype html><html><head><title>demo</title></head><body><app-root></app-root></body></html>";
+
+    private static Action<DefaultHttpContext> WithMethod(string method)
+        => context => context.Request.Method = method;
+
+    [Fact]
+    public async Task A_head_request_keeps_the_full_content_length_it_was_given()
+    {
+        // The shipped regression, pinned: a HEAD must report the length the equivalent GET would
+        // return (RFC 9110 9.3.2), and Kestrel does not catch a wrong one because
+        // VerifyResponseContentLength skips HEAD.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.StaticFileHead(declaredLength: 547),
+            configureContext: WithMethod(HttpMethods.Head));
+
+        Assert.Equal(547, result.Context.Response.ContentLength);
+        Assert.Empty(result.ClientBody.ToArray());
+    }
+
+    [Fact]
+    public async Task A_head_request_does_not_reach_the_prerenderer()
+    {
+        // Pins the *gate* rather than the empty-template guard: this inner pipeline does write a
+        // body, so nothing downstream of the gate would have turned the request away.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            configureContext: WithMethod(HttpMethods.Head));
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, Encoding.UTF8.GetString(result.ClientBody.ToArray()));
+        Assert.Equal(Encoding.UTF8.GetByteCount(IndexHtml), result.Context.Response.ContentLength);
+    }
+
+    [Fact]
+    public async Task A_head_request_does_not_log_a_warning()
+    {
+        // A HEAD is entirely healthy traffic - uptime probes, link checkers, CDN revalidation - and
+        // used to produce one Warning per request about an empty template that was empty by
+        // definition. It is a Debug line now, and it names the method so the reason is legible.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.StaticFileHead(declaredLength: 547),
+            configureContext: WithMethod(HttpMethods.Head),
+            collectLogs: true);
+
+        Assert.DoesNotContain(result.Logs, e => e.Level == LogLevel.Warning);
+
+        var debug = Assert.Single(result.Logs, e => e.Level == LogLevel.Debug);
+        Assert.Contains("HEAD", debug.Message);
+    }
+
+    [Fact]
+    public async Task A_head_request_does_not_wait_for_the_bootmodule_build()
+    {
+        // Why the gate sits before the build await: without that ordering a HEAD blocks on
+        // `ng build` before being turned away downstream anyway.
+        var builder = new PrerenderingHarness.RecordingBootModuleBuilder();
+
+        await PrerenderingHarness.Run(
+            PrerenderingHarness.StaticFileHead(declaredLength: 547),
+            configureContext: WithMethod(HttpMethods.Head),
+            configureOptions: options => options.BootModuleBuilder = builder);
+
+        Assert.Equal(0, builder.BuildCount);
+    }
+
+    [Fact]
+    public async Task A_post_request_is_passed_through_without_prerendering()
+    {
+        // A rendered page is meaningless as the response to a POST, and a consumer middleware
+        // registered inside the SPA callback that answered one with text/html was previously
+        // prerendered. Passed straight through now, body and framing untouched.
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            configureContext: WithMethod(HttpMethods.Post));
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, Encoding.UTF8.GetString(result.ClientBody.ToArray()));
+        Assert.Equal(Encoding.UTF8.GetByteCount(IndexHtml), result.Context.Response.ContentLength);
+    }
+
+    [Fact]
+    public async Task An_options_request_does_not_wait_for_the_bootmodule_build()
+    {
+        // The stated cost of a GET-only gate, made explicit: every other method now skips the build
+        // as well, which is the point rather than a side effect.
+        var builder = new PrerenderingHarness.RecordingBootModuleBuilder();
+
+        await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            configureContext: WithMethod(HttpMethods.Options),
+            configureOptions: options => options.BootModuleBuilder = builder);
+
+        Assert.Equal(0, builder.BuildCount);
+    }
+
+    [Fact]
+    public async Task A_get_request_is_still_prerendered()
+    {
+        // Control, guarding against an inverted gate and against the harness's GET default being
+        // lost - if it were, every test in this file would silently stop exercising the capture.
+        var builder = new PrerenderingHarness.RecordingBootModuleBuilder();
+
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(IndexHtml),
+            configureOptions: options => options.BootModuleBuilder = builder);
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(IndexHtml, result.Service.OriginalHtml);
+        Assert.Equal(1, builder.BuildCount);
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Status204NoContent)]
+    [InlineData(StatusCodes.Status205ResetContent)]
+    [InlineData(StatusCodes.Status304NotModified)]
+    public async Task Does_not_rewrite_the_content_length_of_a_bodyless_response(int statusCode)
+    {
+        // A GET, so the gate cannot help here: these statuses carry no body by definition, so "zero
+        // bytes written contradicts the declared length" is simply not true of them, and rewriting
+        // the length to 0 discards correct metadata.
+        var result = await PrerenderingHarness.Run(context =>
+        {
+            context.Response.StatusCode = statusCode;
+            context.Response.ContentType = "text/html";
+            context.Response.ContentLength = 547;
+            return Task.CompletedTask;
+        });
+
+        Assert.False(result.Service.WasCalled);
+        Assert.Equal(547, result.Context.Response.ContentLength);
+        Assert.Empty(result.ClientBody.ToArray());
+    }
+
+    [Theory]
+    [InlineData(StatusCodes.Status204NoContent)]
+    [InlineData(StatusCodes.Status205ResetContent)]
+    [InlineData(StatusCodes.Status304NotModified)]
+    public async Task Reports_a_bodyless_status_at_debug_rather_than_warning(int statusCode)
+    {
+        // An empty body is *correct* for these statuses, so calling it "a partial representation" at
+        // Warning would teach consumers to ignore this category - the same mistake the empty-template
+        // guard made by warning on every benign HEAD. Warning is reserved for a response that was
+        // supposed to be a document and is not.
+        var result = await PrerenderingHarness.Run(
+            context =>
+            {
+                context.Response.StatusCode = statusCode;
+                context.Response.ContentType = "text/html";
+                context.Response.ContentLength = 547;
+                return Task.CompletedTask;
+            },
+            rawTarget: "/person",
+            collectLogs: true);
+
+        Assert.DoesNotContain(result.Logs, entry => entry.Level == LogLevel.Warning);
+        Assert.Contains(result.Logs, entry => entry.Level == LogLevel.Debug
+            && entry.Message.Contains("carries no response body", StringComparison.Ordinal));
     }
 }
 

--- a/MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs
+++ b/MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs
@@ -1200,6 +1200,24 @@ public class RangeAndTemplateValidityTests
     }
 
     [Fact]
+    public async Task Does_not_warn_about_a_minified_template_whose_closing_tags_were_removed()
+    {
+        // The end tags for html and body are optional, so an HTML minifier legitimately strips
+        // them - and this check originally required a closing </html> as well, which reported a
+        // perfectly good minified document as having no <html> element at all. Observed in the demo,
+        // which runs UseWebMarkupMin inside the SPA callback and so downstream of the capture.
+        var minified = "<!DOCTYPE html><html lang=en><head><title>t</title></head><body><app-root></app-root>";
+
+        var result = await PrerenderingHarness.Run(
+            PrerenderingHarness.HtmlPage(minified),
+            collectLogs: true);
+
+        Assert.True(result.Service.WasCalled);
+        Assert.Equal(minified, result.Service.OriginalHtml);
+        Assert.DoesNotContain(result.Logs, e => e.Message.Contains("no <html> element", StringComparison.Ordinal));
+    }
+
+    [Fact]
     public async Task Warns_once_about_a_fragment_template_and_then_stays_quiet()
     {
         // Two requests through the *same* pipeline. A fragment deployment must not emit a warning

--- a/MintPlayer.AspNetCore.SpaServices.Xsrf/MintPlayer.AspNetCore.SpaServices.Xsrf.csproj
+++ b/MintPlayer.AspNetCore.SpaServices.Xsrf/MintPlayer.AspNetCore.SpaServices.Xsrf.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices.Xsrf</PackageId>
-		<Version>10.7.0</Version>
+		<Version>10.7.1</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/MintPlayer.AspNetCore.SpaServices/MintPlayer.AspNetCore.SpaServices.csproj
+++ b/MintPlayer.AspNetCore.SpaServices/MintPlayer.AspNetCore.SpaServices.csproj
@@ -10,7 +10,7 @@
 
 		<IsPackable>true</IsPackable>
 		<PackageId>MintPlayer.AspNetCore.SpaServices</PackageId>
-		<Version>10.7.0</Version>
+		<Version>10.7.1</Version>
 		<IncludeSymbols>true</IncludeSymbols>
 		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
 		<PackageReadmeFile>README.md</PackageReadmeFile>

--- a/docs/PLAN-Prerendering-Range-Requests.md
+++ b/docs/PLAN-Prerendering-Range-Requests.md
@@ -1,0 +1,94 @@
+# Plan: `originalHtml` is a one-byte slice on a `Range` request
+
+Implementation plan for [PRD-Prerendering-Range-Requests.md](./PRD-Prerendering-Range-Requests.md)
+([issue #80](https://github.com/MintPlayer/MintPlayer.AspNetCore.SpaServices/issues/80)).
+
+Branch: `bugfix/prerendering-range-requests`, from the merged `master`. PR #79 landed as `29db888`
+while this investigation was running, so the HEAD `Content-Length` regression it introduced is
+**already shipped** and is fixed here alongside #80.
+
+## Milestones
+
+### M1 — Investigation ✅ Complete
+
+Three agents, in parallel, no production code written.
+
+| Agent | Scope | Outcome |
+|---|---|---|
+| **A** | Mechanism, cited to ASP.NET Core source | Confirmed end to end. Found that the trigger is any satisfiable single range (including non-`bytes` units), that our `If-Range` strip *aggravates* it, and that it is deterministic rather than a race. |
+| **B** | Reproduction, unit + end to end | Reproduced deterministically. Produced the `Range` matrix in the PRD, confirmed Production-only, and confirmed via Playwright that Chromium sends no `Range` on a document navigation. |
+| **C** | Breadth: what else can be an unusable template | Complete — 5 Tier-A findings, 5 Tier-B, and the decisive one: **NG05104 means exactly one thing**, that the parsed template contained no element matching the app's root selector. Domino never rejects input, so there is no syntax failure mode and plausibility checks cannot work. Also found that `PassThroughAsync` already computes the completeness signal and discards it, and **corrected a claim in the previous PRD** (a downstream `Response.Clear()` *can* shrink our capture buffer). |
+
+Also found, unprompted: **PR #79 rewrites a HEAD response's `Content-Length` to 0.** Verified with a
+throwaway test (expected 547, actual 0), then removed. See the PRD.
+
+### M2 — PRD + plan ✅
+
+This document and the PRD.
+
+### M3 — Reproduction tests (G1)
+
+`Tests/Prerendering/RangeReproTests.cs` currently holds 7 scratch cases from M1. Turn them into a
+committed suite that **fails on the current branch**:
+
+- `bytes=0-0` → the reported one-byte `<`.
+- `bytes=0-99` → **the load-bearing case.** The slice *starts with* `<!doctype html><html lang="en">`,
+  so it defeats any "does this look like HTML?" guard. Any candidate check must be evaluated
+  against this one.
+- `bytes=100-200` → mid-document, no `<html` anywhere in it.
+- `416` → control, already rejected today by `IsSuccessStatusCode`; pinned so a status-check change
+  does not accidentally start accepting it.
+- Multi-range and malformed → controls, already benign (ASP.NET Core ignores the header and serves
+  a full 200); pinned for the same reason.
+- HEAD → full `Content-Length` preserved, no prerender, no warning.
+
+Assert on the template that reaches `OnSupplyData`, using the existing node-free
+`PrerenderingHarness`.
+
+### M4 — Solution team
+
+A team decides the fix rather than defaulting to "strip the header". The PRD lists five candidates;
+the questions that actually need answering:
+
+1. Strip `Range`, narrow the status check, or both? (Defence in depth matters here because the dev
+   proxy can forward a 206 from a third-party dev server that our header surgery never touches.)
+2. If the status check narrows, to `200` only, or to "no `Content-Range` on the response"? Which
+   fails more safely when a consumer's middleware is in the pipeline?
+3. Is a completeness check on the template worth having at all, given the `bytes=0-99` result and
+   given that a false positive silently disables prerendering — the exact reason the
+   `ContentLength` heuristic was rejected in the previous PRD? A well-argued "status and headers are
+   the right layer, content sniffing is not" is an acceptable answer.
+4. GET-only gate: yes or no, and what breaks?
+5. The #79 HEAD regression: fix it in `PassThroughAsync` (skip reconciliation for a bodyless
+   response) or at the source (a method gate that stops HEAD reaching the capture at all)? The
+   second is cleaner if (4) says yes.
+6. What the rejected-template log line should contain so the *next* report of this class arrives
+   with the evidence already in it.
+
+### M5 — Implement + verify
+
+Apply M4's decisions, then one test sweep at the end. Re-run the PRD's `Range` matrix end to end
+against `Demo.Web` in Production, and re-run the previous PRD's 400-abort burst to confirm no
+regression there.
+
+### M6 — Land it
+
+One PR against `master`, referencing #80, in the same symptom → cause → fix → test format as #79.
+
+Version: `master` is at **10.7.0** for all six packages, which #79 shipped. This PR fixes a defect
+in that release, so it needs a bump — **10.7.1** across all six if the lockstep policy from #79
+holds, since the fixes are behavioural corrections rather than new API. Confirm with the maintainer:
+lockstep means all six move even though only Prerendering changes, which is the standing cost that
+policy accepted.
+
+## Notes carried over from the previous PRD
+
+- The middleware is testable without node: `PrerenderingHarness.Run(...)` builds the real delegate;
+  a `RecordingPrerenderingService` captures `originalHtml` and can force a 302 to bail out before
+  the prerenderer. `HttpContext.RequestAborted` and `Request.Method` are both settable on
+  `DefaultHttpContext`.
+- Test-design trap that still applies: assertions about the captured template must use a body shape
+  that actually exercises the defect. The demo's own 547-byte `index.html` is unrepresentative in
+  more than one way.
+- `Response.OnStarting` is a no-op on `DefaultHttpContext`, so anything routed through it is
+  unobservable in the harness and needs `TestServer`.

--- a/docs/PLAN-Prerendering-Range-Requests.md
+++ b/docs/PLAN-Prerendering-Range-Requests.md
@@ -26,10 +26,16 @@ throwaway test (expected 547, actual 0), then removed. See the PRD.
 
 This document and the PRD.
 
-### M3 — Reproduction tests (G1)
+### M3 — Reproduction tests (G1) ✅ Complete
 
-`Tests/Prerendering/RangeReproTests.cs` currently holds 7 scratch cases from M1. Turn them into a
-committed suite that **fails on the current branch**:
+Delivered as `RangeAndTemplateValidityTests` (21 methods / 24 cases) and `RequestMethodGateTests`
+(8 methods / 10 cases) in `Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs`. The scratch
+`RangeReproTests.cs` is deleted; five of its seven cases live on with inverted assertions.
+
+**Red-before-fix verified**, not assumed: reverting the `Range` strip, the GET gate, the framing
+checks and the bodyless narrowing turns **25 tests red**; restoring them gives 362 green.
+
+The original spec, for the record:
 
 - `bytes=0-0` → the reported one-byte `<`.
 - `bytes=0-99` → **the load-bearing case.** The slice *starts with* `<!doctype html><html lang="en">`,
@@ -45,10 +51,30 @@ committed suite that **fails on the current branch**:
 Assert on the template that reaches `OnSupplyData`, using the existing node-free
 `PrerenderingHarness`.
 
-### M4 — Solution team
+### M4 — Solution team ✅ Complete
 
-A team decides the fix rather than defaulting to "strip the header". The PRD lists five candidates;
-the questions that actually need answering:
+Two decision records: [`SOLUTION-range-template-gate.md`](./SOLUTION-range-template-gate.md) and
+[`SOLUTION-head-and-method-gate.md`](./SOLUTION-head-and-method-gate.md).
+
+Decisions taken, against the questions below:
+
+1. **Both** — strip `Range` *and* narrow the gate, because the dev proxy can forward a 206 from a
+   producer our header surgery never reaches. `Range` is deliberately **not** restored afterwards,
+   unlike `Accept-Encoding`, and the reason is in a code comment so it does not get "fixed".
+2. **Status exactly 200, plus a `Content-Range` rejection.** 200-exactly fails *closed* on statuses
+   nobody has considered; "2xx minus the known bad" fails *open* on a 206 whose proxy dropped the
+   header.
+3. **F1-F4 in; decode reframed; structural as warning only; no root guessing.** The declared-vs-captured
+   comparison (F4) **reverses** `SOLUTION-defect2-abort.md` §2 — a correction box now records that
+   there. Decode integrity became `Utf8.IsValid` on the bytes plus a U+0000 check, which is neither
+   of the two options the PRD offered and avoids both of their defects.
+4. **GET only**, gated *before* the build await so a POST no longer blocks on `ng build`.
+5. **Both** — the gate removes the HEAD cause, and the reconciliation is still narrowed for
+   204/205/304, which the gate cannot reach.
+6. Five new Warning lines, one message template per cause, plus the log category changed to the full
+   type name so it is filterable by namespace.
+
+The original questions, for the record:
 
 1. Strip `Range`, narrow the status check, or both? (Defence in depth matters here because the dev
    proxy can forward a 206 from a third-party dev server that our header surgery never touches.)
@@ -67,9 +93,27 @@ the questions that actually need answering:
 
 ### M5 — Implement + verify
 
-Apply M4's decisions, then one test sweep at the end. Re-run the PRD's `Range` matrix end to end
-against `Demo.Web` in Production, and re-run the previous PRD's 400-abort burst to confirm no
-regression there.
+**Implementation ✅.** All of M4's decisions are in
+`SpaPrerenderingExtensions.cs`, plus the `PrerenderingTestContext.Create` default that the GET gate
+required (`HttpRequestFeature.Method` initialises to `string.Empty`, which would otherwise have
+short-circuited every existing test). 362 tests pass; the full solution builds clean.
+
+One defect in the first implementation, caught by the test author rather than by me: a benign
+`204`/`205`/`304` GET was being logged at Warning as "a partial representation" with an empty
+`Content-Range`. Now routed through `CanHaveResponseBody` to a Debug line, with
+`Reports_a_bodyless_status_at_debug_rather_than_warning` pinning it. Also added
+`Does_not_prerender_any_other_success_status` for 201/202/203/226, which the spec's reflection-based
+theory would have covered had the framing checks been factored as a private static — they are inline,
+so the coverage moved to a middleware-level `[Theory]` instead.
+
+**End-to-end verification ✅ Complete.** Results in the PRD. Every `Range` variant now returns a
+fully prerendered 200; `curl -I` reports `Content-Length: 547` where 10.7.0 reported `0`; the
+200-request abort burst produced 0 NG05104 and 0 5xx, matching the previous run; and the baseline
+render is untouched.
+
+The run found one defect of its own — the structural warning fired falsely on any template that had
+been through an HTML minifier, because it required a closing `</html>` that minifiers legitimately
+strip. Fixed, and pinned by a test. 363 tests pass.
 
 ### M6 — Land it
 

--- a/docs/PRD-Prerendering-Aborted-Requests.md
+++ b/docs/PRD-Prerendering-Aborted-Requests.md
@@ -49,10 +49,22 @@ Two things about this are worth stating up front, because they shape the whole i
 The padding decodes to **genuine `\0`, always, in this code path** — `new MemoryStream()` allocates
 a fresh CLR-zeroed array on each grow and copies only `_length` bytes forward. Stale non-zero bytes
 *are* reachable, but only by shrinking and re-writing the same stream instance
-(`SetLength(0)` + rewrite leaves the old tail readable); this middleware creates a fresh stream per
-request and never shrinks it, so "stale/garbage bytes" is **not** reachable here. The only
-hypothetical is a downstream component that resets and re-writes `Response.Body` — noted, not
-reproducible through the real pipeline.
+(`SetLength(0)` + rewrite leaves the old tail readable).
+
+> **Correction (issue #80 investigation).** This document originally concluded that the shrink was
+> "**not** reachable here", because the middleware creates a fresh stream per request and never
+> shrinks it. **That was wrong.** `ResponseExtensions.Clear()` does
+> `if (response.Body.CanSeek) response.Body.SetLength(0)`, our `MemoryStream` *is* seekable, and
+> setting `Response.Body` leaves `IHttpResponseFeature.HasStarted` untouched — so `Clear()` neither
+> throws nor no-ops, it shrinks our capture buffer. Both `ExceptionHandlerMiddlewareImpl` and
+> `DeveloperExceptionPageMiddlewareImpl` reach it, and either can be registered inside the SPA
+> callback. So a downstream `Clear()` is not hypothetical.
+>
+> The consequence is nil **only because** the decode moved from `GetBuffer()` to `TryGetBuffer`,
+> which bounds the read at `Count`. The original `GetBuffer()` decode *would* have appended the
+> stale non-zero tail of the discarded page — i.e. the reporter's "garbage bytes" wording described
+> a real reachable outcome, and the fix in this PR happens to close it. Recorded so the retired
+> claim is not re-inherited.
 
 That supports the severity read: NUL padding after `</html>` is reparented into `<body>` by normal
 HTML parsing and survives to the browser, which is why this went unnoticed for years. It is **not**

--- a/docs/PRD-Prerendering-Range-Requests.md
+++ b/docs/PRD-Prerendering-Range-Requests.md
@@ -1,0 +1,271 @@
+# PRD: `originalHtml` is a one-byte slice on a `Range` request
+
+Upstream report: [issue #80](https://github.com/MintPlayer/MintPlayer.AspNetCore.SpaServices/issues/80)
+by @Reonekot, filed after deploying [PR #79](https://github.com/MintPlayer/MintPlayer.AspNetCore.SpaServices/pull/79)
+to production.
+
+## Overview
+
+A request carrying a `Range` header makes `StaticFileMiddleware` serve a **slice** of `index.html`
+with **HTTP 206**. `UseSpaPrerendering` accepts that slice as a complete SSR template, so
+`originalHtml` becomes `"<"` (for `bytes=0-0`) and Angular throws `NG05104`. The reporter sees it
+"a few times per hour" in production.
+
+**Reproduced, deterministically.** Both in a unit test and end to end against `Demo.Web`. This is
+the third report of the same *shape* — the middleware's notion of "this capture is a usable SSR
+template" being too weak — so this document is deliberately written against the class, not only
+against `bytes=0-0`.
+
+## Problem statement
+
+Three independent conditions have to hold, and all three do
+([`SpaPrerenderingExtensions.cs`](../MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs)):
+
+1. **`Range` is not stripped.** `RemoveConditionalRequestHeaders` (line 341) removes `If-Match`,
+   `If-Modified-Since`, `If-None-Match`, `If-Unmodified-Since` and `If-Range` — but **not**
+   `HeaderNames.Range`.
+2. **206 counts as success.** `IsSuccessStatusCode` (line 338) is `>= 200 && < 300`, so
+   `206 Partial Content` satisfies `canPrerender`, and a 206 *does* carry the file's own
+   `Content-Type: text/html` (verified in source, below).
+3. **The empty-template guard does not fire.** `string.IsNullOrWhiteSpace("<")` is `false`.
+
+### Confirmed mechanism
+
+Pinned to `dotnet/aspnetcore` `release/10.0` @ `668a5ab288b317029bba5ebfe87a7ea6347ea450`.
+
+`ComprehendRequestHeaders` → `ComputeRange` parses `Range` for every GET;
+`ServeStaticFile` then takes `if (IsRangeRequest) { await SendRangeAsync(); return; }`, which sets
+`Content-Range`, sets `Content-Length` to the *slice* length, and calls
+`ApplyResponseHeadersAsync(206)`. That method sets `Content-Type` for any status `< 400` — the
+comment in the framework source says so explicitly: *"these headers are returned for 200, 206, and
+304"*. So we capture `206 + text/html + Content-Range` with a body of exactly `count` bytes.
+
+The slicing survives our `Response.Body` substitution: `StaticFileContext` computes the offset and
+count and passes them *down* as arguments, and `SendFileFallback` does
+`fileStream.Seek(offset)` + copy `count` bytes. **There is no timing window** — unlike the abort
+defect in the previous PRD, this is fully deterministic, which matches the reporter's "logs
+consistently".
+
+### Three corrections to the report
+
+1. **The trigger is far broader than `bytes=0-0`.** *Any satisfiable single range* produces a 206:
+   `bytes=-1` (last byte), `bytes=10-20`, and even `bytes=0-` (the whole file, under a 206). And
+   because neither `RangeHelper.ParseRange` nor `RangeHeaderValue` validates the range **unit**,
+   `Range: items=0-0` works too. **A fix keyed on `bytes=0-0`, or on the `"<"` character, would be
+   incomplete.**
+2. **Our `If-Range` strip is part of the cause, not a bystander.** `ComputeIfRange` is the *only*
+   code path that can cancel an already-parsed range (it clears `IsRangeRequest` when the validator
+   does not match). By removing `If-Range` we guarantee it never cancels — so our own header surgery
+   makes the range *more* likely to be honoured than it would otherwise be.
+3. **Unsatisfiable and multi-range requests are already safe**, for two independent reasons each:
+   an unsatisfiable range yields **416**, which fails `IsSuccessStatusCode` *and* gets no
+   `Content-Type` at all (`ApplyResponseHeadersAsync` sets it only for `< 400`); a multi-range or
+   malformed header is *ignored* by ASP.NET Core, which serves a full 200. Neither needs fixing.
+
+### Measured reproduction
+
+Unit: 7 cases in `Tests/Prerendering/RangeReproTests.cs` (scratch — the committed suite is M3's job).
+
+End to end, `Demo.Web`, `GET /person`, **Production**, instrumented `OnSupplyData`:
+
+| `Range` | Status | `Content-Range` | Template reaching the prerenderer | Client sees |
+|---|---|---|---|---|
+| *(none)* | 200 | – | 456 chars, full document | 200, 25252 B prerendered |
+| `bytes=0-0` | **206** | `bytes 0-0/547` | **1 char: `<`** | **500** (NG05104) |
+| `bytes=0-99` | **206** | `bytes 0-99/547` | 100 chars — *and it starts with `<!doctype html><html lang="en">`* | **500** |
+| `bytes=100-200` | **206** | `bytes 100-200/547` | 101 chars of mid-document, no `<html` at all | **500** |
+| `bytes=999999-` | 416 | `bytes */547` | *(never reaches it)* | 416 |
+| `bytes=0-0,2-2` | 200 | – | 456 chars, full document | 200 prerendered |
+
+Deterministic: 7/7 identical across repeats. The failure chain is
+`NG05104` → `NodeInvocationException` from `SpaPrerenderingExtensions.cs:239` → 500, and the 206's
+`Content-Range` / `Content-Length: 1` **leak onto the error response**.
+
+**The `bytes=0-99` row is the important one for design.** That fragment starts with a doctype and an
+`<html` tag, so any guard that merely asks "does this look like HTML?" would pass it. Whatever
+replaces the current check must be about *completeness*, not plausibility.
+
+### Environment
+
+**Production-only in practice — but by accident, not by design.**
+
+- Development: all six variants returned 200, chunked, no `Content-Range`, full 362-char template.
+  The Angular 21 / Vite dev server does not implement `Range` for its index document.
+- But our own `SpaProxy` **forwards `Range`** (`NotForwardedHttpHeaders` contains only
+  `Connection`), and `CopyProxyHttpResponse` copies both the status and the `Content-Type`. So a
+  dev server that *does* answer 206 for its index document would reproduce this in development
+  identically. **The fix must be proxy-agnostic, not a static-files special case.**
+- Chromium sends **no** `Range` header on a document navigation or reload (verified with Playwright).
+  So this is bot, scanner, CDN or reverse-proxy traffic — consistent with the reporter's guess, and
+  it means user-facing impact is limited to whatever those clients do with a 500.
+
+## ⚠ A shipped regression from PR #79, found by this investigation
+
+**#79 is merged (`29db888`), so this is live on `master`.** Not part of #80, and it is ours:
+
+**`PassThroughAsync` rewrites a `HEAD` response's `Content-Length` to 0.** Verified with a throwaway
+test: expected 547, actual **0**.
+
+`StaticFileMiddleware` answers a HEAD with `SendStatusAsync(200)` — `Content-Type` set,
+`Content-Length` set to the **full** file length, and no body at all. Our empty-template guard
+catches the empty capture and passes through, and then #79's `ContentLength` reconciliation sees
+`547 != 0` and "corrects" the length to 0. A HEAD must report the length the equivalent GET would
+return, so this is a protocol violation introduced by the commit that fixed the synthetic-token
+mismatch.
+
+Second, milder problem on the same path, also from #79: the empty-template guard logs at
+**Warning** for every HEAD, and its code comment claims *"There is no known benign cause, so this is
+worth a warning."* A HEAD is a perfectly benign cause. Every monitoring probe and link checker now
+produces a warning.
+
+Worth noting the silver lining: before #79, a HEAD to a prerendered route produced `NG05104`
+outright. #79's guard accidentally fixed a live bug nobody had reported — the same class again.
+
+## The class, enumerated
+
+`canPrerender` asks two questions — is the status 2xx, is the media type `text/html` — and infers
+"this capture is the complete document the client would have received." **Neither question is about
+completeness.** Every finding below makes both answers true while the inference is false.
+
+### What NG05104 actually means
+
+Traced through the render chain: `prerenderer.js` → the app's `createServerRenderer` →
+`renderApplication({ document })` → `parseDocument` → domino `createWindow`. **Domino never rejects
+input** — any byte sequence becomes *a* document, so there is no syntax-error failure mode at all.
+The single requirement is one line in `_dom_renderer-chunk.mjs`:
+
+```js
+let el = typeof selectorOrNode === 'string' ? this.doc.querySelector(selectorOrNode) : selectorOrNode;
+if (!el) { throw new _RuntimeError(-5104, `The selector "${selectorOrNode}" did not match any elements`); }
+```
+
+So **NG05104 means exactly one thing: the parsed template contained no element matching the app's
+root selector.** That is why "syntactically fine but unusable" is the right framing, and why a
+plausibility check cannot work.
+
+### Tier A — confirmed reachable in a normal deployment
+
+| # | Finding |
+|---|---|
+| **A1** | **`HEAD` → 200 + `text/html` + full `Content-Length` + zero bytes.** Caught by the empty-template guard, but as a *false alarm*: every HEAD to a SPA route logs at **Warning**, indistinguishable from a real fault. Plus the #79 `Content-Length` regression above. No HEAD coverage exists anywhere in the prerendering tests. |
+| **A2** | **206.** Three additions to the mechanism above: a 206 can carry the *complete* document (`bytes=0-`), so "206 ⇒ truncated" is false — rejecting it is still right, because `Content-Range` framing cannot survive a rewritten body. Other producers reachable inside the capture: an MVC `FileResult` with `enableRangeProcessing: true`, and `MapStaticAssets` if ever positioned inside. |
+| **A3** | **The completeness signal already exists and is used backwards.** `PassThroughAsync` computes `ContentLength.HasValue && ContentLength != outputBuffer.Length` — exactly the check the middleware lacks — and *overwrites the declared value* instead of concluding "this capture is not the document." It is also the only check that can catch the abort case (b) mid-copy truncation that the empty guard provably cannot. |
+| **A4** | Nothing on the response is inspected except status class and media type. Never read: `Content-Range`, `Content-Encoding`, `Transfer-Encoding`, `Request.Method`, or A3's length comparison. |
+| **A5** | Deferred status codes still defeat the post-`OnSupplyData` check — `SkipPrerendering()` is opt-in, and the demo's own service sets a 404 from inside `OnStarting`. |
+
+### Tier B — needs an unusual but realistic configuration
+
+| # | Finding |
+|---|---|
+| **B1** | **`Content-Encoding`.** The `Accept-Encoding` strip is a precaution with no check behind it. No currently-reachable compressed capture found (`ResponseCompressionMiddleware` is double-gated; `StaticFileMiddleware` does *no* pre-compressed on-disk negotiation — that hypothesis is retired). But `MapStaticAssets` serves Brotli variants as separate endpoints and copies `Content-Encoding` verbatim, reachable when endpoint *selection* is upstream of our strip and *execution* downstream. Compressed bytes then get `Encoding.UTF8.GetString`-ed. |
+| **B2** | **Non-UTF-8 charset.** `IsHtmlContentType` accepts any parameters; the decode hard-codes UTF-8. `text/html; charset=utf-16` decodes to `<\0!\0d\0…` — and `char.IsWhiteSpace('\0')` is **false**, so it sails past the empty guard into NG05104. Needs a custom content-type provider, so unusual rather than theoretical. |
+| **B3** | **A downstream error or status page becomes the template — the most misleading case of all.** `UseExceptionHandler` / `UseStatusCodePagesWithReExecute` registered *inside* the SPA callback puts the error page inside the capture (the demo's own commented-out `spa.ApplicationBuilder.UseResponseCaching()` invites exactly that placement). `ExceptionHandlerOptions.StatusCodeSelector` is an unconstrained `Func<Exception,int>`, and a re-executed MVC `Ok()` turns a 404 into a 200. Result: 200 + `text/html` + a complete, well-formed, non-empty error page with no app root → NG05104, from a template that passes every check and **looks perfectly healthy in a log**. |
+| **B4** | **`Response.Clear()` while our `MemoryStream` is installed is reachable — and this corrects the previous PRD.** `ResponseExtensions.Clear` does `if (response.Body.CanSeek) response.Body.SetLength(0)`; our buffer is seekable and `HasStarted` is untouched, so it neither throws nor no-ops — it *shrinks our buffer*. Both `ExceptionHandlerMiddlewareImpl` and `DeveloperExceptionPageMiddlewareImpl` reach it. The consequence is nil **only because** the decode moved to `TryGetBuffer`; the pre-#79 `GetBuffer()` would have appended the stale tail of the discarded page. Also: `Clear()` wipes all headers, so a downstream `Clear()` that forgets `Content-Type` silently turns prerendering off. |
+| **B5** | **Buffered writes that never reach the buffer.** `StreamResponseBodyFeature.Writer` is a `PipeWriter` whose bytes reach the stream only on flush, and its `StartAsync` flushes the *stream*, not the writer. We read the buffer immediately after `next()` and never call the feature's `CompleteAsync`. No current instance found (`WriteAsync`, MVC and Razor all flush explicitly), but a custom middleware or third-party body wrapper would hand us a short capture with no abort involved. |
+
+### Tier C — theoretical or unreachable here
+
+203 (no producer in ASP.NET Core or this repo), 226 (nothing implements delta encoding), 204/205
+(must have no body; benign *only because* the empty guard fires — with a body present, Kestrel's
+`HandleNonBodyResponseWrite` would throw).
+
+**Non-GET methods carry no corrupt-template route** — `StaticFileMiddleware` declines without
+touching the response and the request falls to `SpaDefaultPageMiddleware`'s terminal throw. But they
+do cost something: the SSR bundle build is awaited **first**, so a `POST` or `OPTIONS` to a SPA route
+blocks on `ng build`. Prerendering is meaningful only for GET.
+
+## Goals
+
+| # | Goal |
+|---|---|
+| G1 | A `Range` request never yields a partial SSR template. Covered by tests that fail on the current branch. |
+| G2 | Fix the *class*: a status that does not promise the complete representation must never be treated as a template, whatever produced it (static files, dev proxy, or a consumer's middleware). |
+| G3 | Replace or supplement the `IsNullOrWhiteSpace` guard so a short-but-non-empty capture is rejected — without inventing a check that a legitimate template could fail. |
+| G4 | Fix the #79 HEAD `Content-Length` regression, and stop warning on benign HEADs. |
+| G5 | Decide whether prerendering should apply to non-GET methods at all. |
+| G6 | Land it with the rest of the work (see the open question on PR placement). |
+
+## Non-goals
+
+- Honouring `Range` *correctly* for prerendered output. A prerendered page has no stable byte range
+  to slice — the whole point is that the body is generated per request. Ignoring `Range` is both
+  permitted (a server MAY ignore it) and the only coherent option.
+- Reproducing against IIS or HTTP.sys. Kestrel only, as before.
+
+## Candidate fixes (the solution phase decides)
+
+Stated as options with their trade-offs, not as a decision.
+
+1. **Strip `Range` alongside the conditional headers.** Directly consistent with what that method
+   already does and why — we strip `If-None-Match` precisely so we do not capture a 304. Making it
+   strip `Range` too means static files serves the full 200 we actually want. Note this also
+   *repairs* correction 2: with both `Range` and `If-Range` gone, there is nothing to cancel.
+   Open question: restore it afterwards, as we do for `Accept-Encoding`? Nothing downstream of the
+   capture reads it, but symmetry may be worth it.
+2. **Narrow the status check.** `IsSuccessStatusCode` is used for `canPrerender`; a template must be
+   a complete representation, which realistically means **200 only**. Alternatively reject on the
+   presence of a `Content-Range` response header, which is set on the 206 and 416 paths and never on
+   the 200 path. Defence in depth against a 206 arriving from the dev proxy or a consumer's
+   middleware even after (1).
+3. **A completeness check on the captured template — in layers, from the breadth survey.** Strongest
+   per unit of cost first, and note the split between *invariants* and *heuristics*:
+   1. **Framing invariants that prove "this is the whole document"**: status exactly 200 (not 206),
+      no `Content-Range`, `Content-Encoding` absent or `identity`, method is GET, and — if
+      `ContentLength` was declared — captured bytes == declared bytes. All app-agnostic, all
+      decisive, and together they cover A1, A2, B1 *and* the abort case (b) truncation the empty
+      guard provably cannot. **A3 is the point: that last comparison is already computed in
+      `PassThroughAsync` and thrown away.**
+   2. **Decode integrity**: reject a capture that decodes to U+FFFD or contains U+0000 (equivalently,
+      decode with `throwOnInvalidBytes: true`). Neither can occur in a valid template, and both are
+      exactly what B1's compressed bytes and B2's wrong charset produce. This is the only check that
+      catches those two without knowing anything about the app.
+   3. **Structural HTML as a logged *warning*, not a rejection**: presence of `<html` and `</html>`.
+      Honest about the limit — a fragment template is legitimate (domino normalizes a bare
+      `<app-root></app-root>` into a full document and the render succeeds), so a hard rejection
+      would break a working deployment for no proven gain. True in practice for any `ng build`
+      output, false in principle. Log it with the first ~200 characters of the template — precisely
+      the diagnostic the reporter had to hand-build.
+   4. **Not worth asserting at all**: any guess at the root element. `<app-` prefix matching,
+      "contains a hyphenated custom element", "has a child of `<body>`" all fail on real apps and
+      would turn working deployments into 500s. `Contains("<our-app")` is correct *for the reporter*
+      and correctly lives in *their* `OnSupplyData`. If an in-library strong check is wanted, the
+      only sound route is opt-in: a configured root selector or a template predicate on
+      `SpaPrerenderingOptions`.
+
+   Note from the measurements that a leading-doctype check would **not** have caught `bytes=0-99`,
+   which is why layer 3 is a warning and layers 1-2 do the actual work.
+4. **A method gate.** Prerendering only makes sense for GET. A gate would fix the HEAD path cleanly
+   at the source — no capture, no warning, no `ContentLength` rewrite — and would stop a POST that
+   happens to return `text/html` from being prerendered. Needs a judgement on whether any consumer
+   legitimately relies on prerendering a non-GET.
+5. **Log enough to identify the client.** The reporter had to add their own logging to get this far.
+   A rejected-template log line carrying the method, status, `Content-Range` and User-Agent would
+   have identified this in one reading.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Stripping `Range` means a client asking for bytes gets a full page | Correct and permitted; a prerendered body cannot satisfy a byte range. Same precedent as the conditional headers we already strip. Call it out in the release notes. |
+| A completeness check rejects a legitimate template and silently disables prerendering | The measured slices are the test set, and the previous PRD's rejection of the `ContentLength` heuristic is the precedent: a false positive here is worse than the bug. Prefer status/header-based rejection over content sniffing. |
+| A method gate changes behaviour for a consumer prerendering a non-GET | Assess first; if adopted, release-note it. GET-only matches what `StaticFileMiddleware` itself serves. |
+| Fixing the HEAD regression inside #79 rewrites an open PR under review | It is a protocol violation we introduced; shipping it knowingly is worse. Raise with the maintainer (open question below). |
+
+## Success criteria
+
+- Tests that fail on the current branch and pass after the fix, covering: `bytes=0-0`, a
+  markup-shaped slice (`bytes=0-99`), a mid-document slice (`bytes=100-200`), and 416 as a control.
+- The `Range` end-to-end matrix above re-run against the fix: every variant either prerenders the
+  full page or is passed through, with **no** 500 and no `NG05104`.
+- HEAD reports the full `Content-Length`, does not warn, and does not reach the prerenderer.
+- No regression in the 400-abort verification from the previous PRD.
+
+## Placement — resolved
+
+PR #79 was merged as `29db888` before this investigation finished, so the question of folding into
+it is moot. This work goes on `bugfix/prerendering-range-requests`, branched from the merged
+`master`, as one new PR covering issue #80 **and** the shipped HEAD regression.
+
+That changes the HEAD item's urgency rather than its content: it is no longer "do not ship this",
+it is "this shipped in 10.7.0 and needs a fix release". Worth a line in the PR body so the
+maintainer can decide whether 10.7.0 needs pulling or simply superseding.

--- a/docs/PRD-Prerendering-Range-Requests.md
+++ b/docs/PRD-Prerendering-Range-Requests.md
@@ -253,12 +253,65 @@ Stated as options with their trade-offs, not as a decision.
 
 ## Success criteria
 
-- Tests that fail on the current branch and pass after the fix, covering: `bytes=0-0`, a
-  markup-shaped slice (`bytes=0-99`), a mid-document slice (`bytes=100-200`), and 416 as a control.
-- The `Range` end-to-end matrix above re-run against the fix: every variant either prerenders the
-  full page or is passed through, with **no** 500 and no `NG05104`.
-- HEAD reports the full `Content-Length`, does not warn, and does not reach the prerenderer.
-- No regression in the 400-abort verification from the previous PRD.
+| # | Criterion | Status |
+|---|---|---|
+| 1 | Tests that fail before the fix and pass after, covering `bytes=0-0`, the markup-shaped slice, the mid-document slice, and 416 as a control | ✅ **Verified in both directions.** Reverting the `Range` strip, the GET gate, the framing checks and the bodyless narrowing turns **25 tests red**; restoring them gives **362 green**. |
+| 2 | The `Range` end-to-end matrix re-run against the fix — every variant prerenders the full page or passes through, no 500, no `NG05104` | ✅ **All seven variants → 200, 25252 B, fully prerendered.** No 206 reaches the client, no `Content-Range` header anywhere, nothing logged. |
+| 3 | HEAD reports the full `Content-Length`, does not warn, does not reach the prerenderer | ✅ Unit (`RequestMethodGateTests`) **and** end to end: `curl -I /person` → `Content-Length: 547` (was `0`), one Debug line naming the method, zero Warnings. |
+| 4 | No regression in the 400-abort verification from the previous PRD | ✅ 200 real Chromium aborts: **0 NG05104, 0 5xx, 0 empty-template prerenders**, 195 complete templates, 6 abort-skip Debug lines. |
+
+### End-to-end results (Production, `Demo.Web`)
+
+| `Range` | Before | After |
+|---|---|---|
+| *(none)* | 200, 25252 B | 200, 25252 B |
+| `bytes=0-0` | **206 → 500 NG05104** | **200, 25252 B, prerendered** |
+| `bytes=0-99` | **206 → 500** | **200, 25252 B** |
+| `bytes=100-200` | **206 → 500** | **200, 25252 B** |
+| `bytes=999999-` | 416 | **200, 25252 B** — see the behaviour note below |
+| `bytes=0-0,2-2` | 200, 25252 B | 200, 25252 B |
+| `bytes=-1` | *(untested)* | 200, 25252 B |
+
+Baseline unaffected: `/person` still returns 25252 bytes of real prerendered markup, 0.03-0.06 s warm.
+`GET /` still redirects with a 456-byte pass-through rather than a prerendered page.
+
+**Behaviour change for the release notes:** `bytes=999999-` no longer returns **416**, it returns a
+full 200. The header is gone before `StaticFileMiddleware` sees it, so unsatisfiability can no longer
+be detected. Consistent with the non-goal above (a server MAY ignore `Range`, and a prerendered body
+has no stable byte range to slice), but it is a visible difference.
+
+### Two findings from the verification run
+
+1. **The structural warning was a false positive under an HTML minifier — fixed.** The check
+   required both `<html` and `</html>`, but the end tags for `html` and `body` are optional, so
+   aggressive minification legitimately strips them. The demo runs `UseWebMarkupMin` inside the SPA
+   callback, i.e. downstream of the capture, so its perfectly good 456-character template was
+   reported as having "no `<html>` element". The check now requires only the opening tag, which is
+   not optional and not stripped. Pinned by
+   `Does_not_warn_about_a_minified_template_whose_closing_tags_were_removed`.
+2. The synthetic abort probe still 500s with a `Content-Length` mismatch, from the minifier's
+   declared length rather than from this middleware. Unreachable on a genuine socket abort — 0
+   occurrences across 200 real aborts — and already documented in `SOLUTION-defect2-abort.md`.
+
+**Not reachable in this demo:** the gate's non-GET Debug line for `POST`. Endpoint routing answers
+`405 Allow: GET, HEAD` *upstream* of `UseSpaPrerendering`, so only `HEAD` exercises that branch here.
+The behaviour is right; the log line is simply unobservable in this app.
+
+### Coverage of the enumerated class
+
+| Finding | Closed? |
+|---|---|
+| A1 HEAD | ✅ GET gate; `Content-Length` regression fixed |
+| A2 206 / partial | ✅ `Range` stripped, status must be exactly 200, `Content-Range` rejected |
+| A3 completeness signal discarded | ✅ now a rejection (F4), narrowed and logged |
+| A4 nothing inspected but status class and media type | ✅ method, `Content-Range`, `Content-Encoding` and length are all read now |
+| A5 deferred status codes | ➖ unchanged — `SkipPrerendering()` remains opt-in, as designed |
+| B1 `Content-Encoding` | ✅ F3 |
+| B2 non-UTF-8 charset | ✅ `Utf8.IsValid` + the NUL check |
+| B3 error page as template | ❌ **Not closed, by construction.** A complete, well-formed error page passes every check, including the structural one. Documented instead: the README warns against registering `UseExceptionHandler`/`UseStatusCodePagesWithReExecute` inside the SPA callback, and shows the consumer-side assertion in `OnSupplyData`. The eventual answer is an opt-in template predicate on `SpaPrerenderingOptions`. |
+| B4 `Response.Clear()` shrinking the buffer | ➖ Incidental — harmless since the decode moved to `TryGetBuffer`. The previous PRD's claim that it was unreachable is corrected there. |
+| B5 unflushed writer | ✅ when a length is declared (F4); otherwise the empty guard |
+| Tier C (203/204/205/226) | ✅ rejected by the exactly-200 check; 204/205/304 report at Debug, since an empty body is correct for them |
 
 ## Placement — resolved
 

--- a/docs/SOLUTION-defect2-abort.md
+++ b/docs/SOLUTION-defect2-abort.md
@@ -144,6 +144,22 @@ is the only mechanical way to spot case (b). It is still the wrong thing to bran
 
 `ContentLength` does earn its keep — as **data in a log message**, not as a branch. See §3.
 
+> **Reversed by the issue #80 investigation.** See
+> [`SOLUTION-range-template-gate.md`](./SOLUTION-range-template-gate.md) §3.1.1, which reinstates
+> this comparison as a rejection. The first argument above — the load-bearing one — does not hold:
+> a transforming middleware that left a stale `ContentLength` behind would fail Kestrel's own
+> Content-Length verification on **every** response, on every route this middleware never touches.
+> `UseWebMarkupMin` updates the length as it minifies, which is why the demo works at all. So a
+> mismatch means truncation or an unflushed writer, not transformation.
+>
+> The reinstated form is narrower than what was rejected here, and answers the other two objections
+> rather than overriding them: it fires **only** when a length is declared (so the chunked
+> dev-proxy shape is untouched, and the abort check remains its only cover), **only**
+> one-directionally (captured < declared, since a longer capture cannot be a truncation), and it
+> **logs at Warning** — the objection above was really about a *silent* false positive.
+> `Prerenders_a_response_a_transforming_middleware_shrank` is the regression guard: if that test
+> ever fails, this rejection was right and the reversal was wrong.
+
 **A minimal structural check (`contains "<html"`, `</body>`, …) — rejected.** It buys almost
 nothing: a template truncated mid-`<body>` still contains `<html`, so the check passes on the very
 case it was invented for, while a legitimate consumer supplying a fragment rather than a full

--- a/docs/SOLUTION-head-and-method-gate.md
+++ b/docs/SOLUTION-head-and-method-gate.md
@@ -1,0 +1,361 @@
+# Solution: the HEAD `Content-Length` regression, and a request-method gate
+
+Scope: two items from `PRD-Prerendering-Range-Requests.md` — **G4** (the shipped HEAD
+`Content-Length` regression and the benign-HEAD warning) and **G5** (should prerendering apply to
+non-GET methods). Deliberately *not* in scope: `canPrerender`, `RemoveConditionalRequestHeaders`,
+`ReadCapturedHtml`, and the empty-template guard's *rejection* logic — those belong to the
+`Range`/206 workstream. Coordination points with that workstream are marked **[shared]**.
+
+This document decides; it contains no production code.
+
+---
+
+## 1. Decision summary
+
+| # | Decision |
+|---|---|
+| D1 | **Gate prerendering to GET.** A non-GET request is passed straight through: no bundle build await, no header surgery, no capture, no prerender. |
+| D2 | **Place the gate after the excluded-URL loop and before the bundle build await.** That placement is what also removes the wasted `ng build` block. |
+| D3 | **Also narrow the `PassThroughAsync` reconciliation** to responses that can carry a body (skip it for HEAD and for 204/205/304). The gate makes this unreachable for HEAD, but the reconciliation is wrong *in principle* for a bodyless response and 304/204 remain reachable on a GET. |
+| D4 | **Keep the empty-template guard at Warning**, but rewrite its comment and add `{Method}`/`{StatusCode}` to the message. HEAD — the one benign cause we knew of — is gated away upstream, so the level is now defensible. |
+| D5 | **No new public option.** No `PrerenderedMethods` / method predicate on `SpaPrerenderingOptions` until a consumer actually asks. |
+| D6 | 10.7.0 is **superseded by 10.7.1, not pulled**. Severity is low-to-moderate and affects HEAD only. |
+
+---
+
+## 2. The HEAD `Content-Length` regression (G4)
+
+### 2.1 What is actually happening
+
+`PassThroughAsync` (`SpaPrerenderingExtensions.cs:271-279`) reconciles unconditionally:
+
+```csharp
+if (context.Response.ContentLength.HasValue && context.Response.ContentLength != outputBuffer.Length)
+{
+    context.Response.ContentLength = outputBuffer.Length;
+}
+```
+
+For a HEAD, `StaticFileMiddleware` answers `200` + `text/html` + the **full** file
+`Content-Length` and writes **no body** — which is exactly right. Our capture is therefore
+legitimately empty, the empty-template guard fires, and the reconciliation then "corrects" a
+correct `547` to `0`. Measured in the PRD: expected 547, actual 0.
+
+The reconciliation's own doc-comment states its justification precisely: it exists for *"the
+request's abort token cancelled while the connection is still alive"*, where Kestrel would otherwise
+fail the response with `Response Content-Length mismatch: too few bytes written`. That justification
+does not extend to a HEAD — Kestrel's `VerifyResponseContentLength` skips HEAD outright, so there is
+nothing to reconcile away and the rewrite buys nothing while destroying real metadata.
+
+### 2.2 Which shape to fix — both, and why
+
+**The gate (D1) is the primary fix.** It is a fix at the source: a HEAD never enters the capture, so
+the empty capture, the false-alarm warning and the `ContentLength` rewrite all cease to exist rather
+than being individually patched. Three defects collapse into one three-line check. That is the
+right altitude: the bug is not "the reconciliation mishandles HEAD", it is "the middleware has no
+notion of which methods prerendering applies to" (PRD A4: `Request.Method` is never read).
+
+**But the reconciliation is still wrong in principle, so narrow it too (D3).** Reasons, in order of
+weight:
+
+1. **The invariant is about the response, not about HEAD.** "Zero captured bytes contradicts a
+   declared length" is only true for a response that *may* carry a body. For a bodyless response —
+   HEAD, `204`, `205`, `304` — zero bytes is the correct and expected outcome, and a declared length
+   is metadata about the representation, not a promise about this message. Rewriting it is a
+   category error that happens to be observable on HEAD first.
+2. **204/205/304 remain reachable on a GET, today.** `PassThroughAsync` is the destination for every
+   non-prerenderable response. A `304` is unlikely from static files (we strip the conditional
+   headers) but entirely reachable from a dev-server response copied by `SpaProxy`, or from a
+   consumer's middleware inside the callback; `204`/`205` are reachable from any consumer endpoint
+   registered inside the capture. The gate does nothing for those. (PRD Tier C already flags 204/205
+   as "benign *only because* the empty guard fires" — that is exactly the population this narrowing
+   protects.)
+3. **The path the reconciliation serves is itself unusual.** By its own comment it insures a
+   synthetic cancelled token on a live connection — a request-timeout feature or a linked token.
+   Cheap insurance is fine; cheap insurance that mutates correct headers on a much more common path
+   is not. Keeping the insurance and constraining it to the case it was written for costs one
+   predicate.
+4. **Defence against the gate being relaxed later.** If anyone ever adds an opt-in for a non-GET
+   method (D5's escape hatch), the reconciliation must not silently reintroduce this bug.
+
+Shape: a `CanHaveResponseBody(HttpContext)` predicate — not HEAD, and status not `204`/`205`/`304` —
+guarding the existing `if`. It belongs inside `PassThroughAsync`, which already owns the
+reconciliation and already has the context; the caller does not need to know.
+
+### 2.3 RFC position
+
+RFC 9110 §9.3.2: a server *SHOULD* send the same header fields for a HEAD as it would have for a
+GET, *but* "MAY omit header fields for which a value is determined only while generating the
+content." So:
+
+- `Content-Length: 0` on a HEAD to a 547-byte resource is a SHOULD violation and, worse, actively
+  misinforms caches and clients that the resource is empty.
+- After the fix, the HEAD reports `547` (the static template) while the equivalent GET returns a
+  prerendered body of a different, generated length with no `Content-Length` at all
+  (`ServePrerenderResult` does `Response.Clear()` then `WriteAsync`, i.e. chunked). That mismatch is
+  explicitly permitted by the "determined only while generating the content" carve-out, and it is
+  the same answer any SSR framework gives. Reporting a plausible static length is strictly better
+  than reporting zero.
+
+### 2.4 What happens to the test that pins the reconciliation
+
+`AbortedRequestTests.Reconciles_a_declared_content_length_with_the_empty_body_it_passes_through`
+(`SpaPrerenderingMiddlewareTests.cs`) uses `AbortedStaticFile(declaredLength: 547)` — status `200`,
+`text/html`, aborted token — and asserts `ContentLength == 0`.
+
+- Under **D3 alone** it passes unchanged: the response is a body-bearing `200`, so the reconciliation
+  still applies.
+- Under **D1** it passes *only if the harness supplies a method*. **This is a real trap, verified:**
+  `HttpRequestFeature.Method` initialises to `string.Empty`, so every harness request currently has
+  `Request.Method == ""`, which is neither GET nor HEAD (`HttpMethods.IsGet("") == false` — probed
+  against the real types, not recalled). A GET-only gate would therefore short-circuit **every
+  existing prerendering harness test**, and this test in particular would see `ContentLength == 547`
+  and fail.
+
+**[shared] Required harness change:** default the method to GET in
+`PrerenderingTestContext.Create` (`SpaPrerenderingExtensionsTests.cs:49`) — the single construction
+site the middleware harness uses — so a harness request models a real request and `configureContext`
+can still override it. With that in place the reconciliation test passes **untouched**, which is the
+outcome to aim for: leaving it unedited makes it double as the pin proving the harness default is
+present. The `Range` workstream needs the same default; whoever lands first adds it.
+
+---
+
+## 3. Should prerendering be gated to GET? (G5)
+
+### 3.1 Decision: GET only
+
+**GET+HEAD is not a coherent option.** Prerendering a HEAD cannot work even in principle: static
+files writes no body for a HEAD, so the capture is empty and there is no template to render. Adding
+HEAD to the gate would land us straight back on the empty-template guard, the warning noise, and the
+`ContentLength` rewrite — i.e. it fixes nothing. If, instead, the intent were "render the page and
+throw the body away", we would pay a full node round-trip per monitoring probe for a
+`Content-Length` we then discard. Rejected on both counts.
+
+**No gate at all** leaves three costs standing:
+
+1. **The wasted build.** The bundle build is awaited before the capture, so a `POST` or `OPTIONS` to
+   a SPA route blocks on `ng build` — first-request latency, and in the worst case a build failure
+   surfaced on a request that had nothing to do with prerendering.
+2. **A semantically wrong prerender.** A consumer endpoint registered *inside* the SPA callback that
+   answers a `POST` with `text/html` is prerendered as if it were the SPA shell. The SPA shell is not
+   the representation of a POST result.
+3. **The HEAD trio above** stays alive as three separate patches instead of one gate.
+
+### 3.2 What breaks for a consumer
+
+Almost nothing, because non-GET requests do not work on a SPA route today either. Traced:
+`StaticFileMiddleware` declines a non-GET/HEAD without touching the response, the request reaches
+`SpaDefaultPageMiddleware`'s terminal `throw new InvalidOperationException(...)`
+(`MintPlayer.AspNetCore.SpaServices/Internal/SpaDefaultPageMiddleware.cs:63`), and the consumer gets
+a 500. Before and after the gate, identical — the gate only removes the build wait in front of it.
+
+The single behavioural change is case 2 above: a consumer whose own middleware, registered inside
+the SPA callback, answers a non-GET with `text/html` and *relies* on that being prerendered. That is
+semantically wrong, undocumented, and has never been tested. Release-note it. If someone reports it,
+the escape hatch is an opt-in `SpaPrerenderingOptions` member (a method set, or a
+`Func<HttpContext,bool>` predicate) — **not added now** (D5): adding configuration for a
+hypothetical consumer pushes the decision back onto every user and would need its own reconciliation
+interaction (§2.2 point 4).
+
+HEAD consumers are also strictly better off: pre-#79 a HEAD to a prerendered route produced
+`NG05104` outright; #79 turned that into a 200 with a wrong `Content-Length` plus a warning; the gate
+turns it into the plain static-file answer.
+
+### 3.3 Placement (D2)
+
+Current order inside the `applicationBuilder.Use(...)` delegate:
+
+1. `Response.OnStarting(...)` registering `options.OnPrepareResponse`
+2. the excluded-URL loop → `await next(); return;`
+3. the bundle build await (`bootModuleBuildTask.Value`)
+4. `RemoveConditionalRequestHeaders` + `Accept-Encoding` strip
+5. the capture (`MemoryStream` substitution) and everything after it
+
+**The gate goes between 2 and 3**, doing the same `await next(); return;` as the exclude loop.
+
+Why there:
+
+- **Before 3** is the load-bearing part: it is what stops a `POST`/`OPTIONS`/`HEAD` blocking on
+  `ng build`. A gate placed after the build await would fix the HEAD headers and the wrong-prerender
+  case but leave the wasted build — the PRD's own reason for raising G5.
+- **After 1**, so `OnPrepareResponse` keeps firing for every method exactly as today. That callback
+  is a consumer hook for setting headers on the pass-through response; silently dropping it for HEAD
+  would be a second, quieter regression. (The exclude loop already sits after 1 for the same
+  reason.)
+- **After 2** rather than before it, for one reason only: log noise. A skip log placed before the
+  exclude loop would fire for every non-GET hit on `/dist/*` and friends. Behaviourally the two
+  orderings are equivalent — both terminate in `await next(); return;` — so this is a diagnostics
+  choice, taken deliberately rather than by accident.
+
+Log level for the skip: **Debug**, with `{Method}` and `{Path}`. It is a normal, expected outcome,
+not an anomaly.
+
+---
+
+## 4. The HEAD warning noise (D4)
+
+Today the empty-template guard logs at **Warning** for *every* HEAD to a SPA route, with the comment
+*"There is no known benign cause, so this is worth a warning."* A HEAD is a benign cause, so the
+comment is false as written, and every uptime probe and link checker produces a warning.
+
+**With the gate, the HEAD path never reaches the guard** — the gate returns at step 2/3, long before
+the capture is installed, so no HEAD can produce an empty capture. Confirmed by construction, and
+pinned by a test (§5, test 3).
+
+The comment should stop asserting the absence of benign causes and instead say which ones were
+*removed* and what remains:
+
+> An empty template is never something the prerenderer can work with, and handing it to Node is what
+> produces an unhelpful NG05104 instead of a diagnosable message. The one benign producer we know of
+> — a HEAD, which static files answers with headers and no body — is short-circuited by the method
+> gate above and cannot reach here, so an empty capture on a GET means the body was never written
+> when it should have been. That is worth a warning.
+
+Two supporting changes:
+
+- **Add `{Method}` and `{StatusCode}` to the message.** The reporter in #80 had to hand-build this
+  logging (PRD candidate 5). If a benign producer we have not thought of turns up, the log line
+  should identify it in one reading instead of provoking a second investigation.
+- **[shared] Optional, and it touches the other workstream's guard:** a `204`/`205` on a GET reaching
+  the empty guard is *also* benign (an empty body is correct there), and would still warn. The
+  cleanest form is to reuse the same `CanHaveResponseBody` predicate from §2.2 to log at Debug in
+  that case and Warning otherwise. Recommended but explicitly flagged: the guard body is the
+  `Range`/206 agent's file region, so reconcile at merge rather than editing it twice.
+
+---
+
+## 5. Is a prerendered body ever written to a HEAD response today? (Q4)
+
+**No body reaches the wire today, and the change does not weaken that — it strengthens it.** Verified
+against the code rather than taken from the PRD:
+
+- **The normal HEAD path never renders.** static files → `200`/`text/html`/full `Content-Length`/no
+  body → empty capture → the empty guard returns via `PassThroughAsync`, which copies zero bytes.
+  `Prerenderer.RenderToString` is never reached, so there is no prerendered body to write.
+- **The PRD's claim needs one correction, in our favour.** "Kestrel silently discards HEAD body
+  writes anyway" is true of the *real* response body, but **not** of the capture: while our
+  `MemoryStream` is installed, `Kestrel`'s non-body-response handling is bypassed entirely, so a
+  consumer middleware inside the callback that *does* write a body on a HEAD would fill our buffer,
+  clear the empty guard, and get prerendered. What then happens is that `ServePrerenderResult` calls
+  `Response.Clear()` (wiping status-relevant headers and `Content-Length`), sets
+  `Content-Type: text/html`, possibly overwrites the status from `renderResult.StatusCode`, and
+  `WriteAsync`es the page into the *real* body — where Kestrel discards it, and
+  `VerifyResponseContentLength` skips HEAD so nothing complains. So today's HEAD protection is "no
+  body on the wire, but the response headers can still be rewritten by a render that was never
+  appropriate", and the render itself (a full node round-trip) still happens.
+- **Under the gate that entire path becomes unreachable for HEAD**, including the header rewrite and
+  the wasted render. The protocol-violation surface strictly shrinks; nothing about it grows.
+
+`204`/`205` with a body written inside the capture remains a real hazard (`Kestrel`'s
+`HandleNonBodyResponseWrite` would throw on the pass-through write) — unchanged by this work, and
+noted in the PRD's Tier C. The §2.2 narrowing does not make it worse: it only declines to *mutate*
+the declared length.
+
+---
+
+## 6. Tests (committed, node-free)
+
+All against `PrerenderingHarness` in
+`MintPlayer.AspNetCore.SpaServices.Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs`. There is
+no HEAD coverage anywhere in the prerendering tests today, which is precisely why this shipped.
+
+### 6.1 Harness additions
+
+1. **[shared] `PrerenderingTestContext.Create` defaults `Method` to `HttpMethods.Get`.** Mandatory —
+   see §2.4. Without it a GET-only gate fails the whole existing suite.
+2. **`PrerenderingHarness.StaticFileHead(long declaredLength)`** — a new inner pipeline modelling
+   what `StaticFileMiddleware` leaves behind for a HEAD: `200`, `text/html`,
+   `ContentLength = declaredLength`, **no body**, no exception. Deliberately distinct from
+   `AbortedStaticFile`, which is byte-identical in effect but models a different contract; two names
+   keep the two contracts from being conflated when one of them changes.
+3. **A collecting logger.** The harness registers no `ILoggerFactory`, so `LoggerFinder` currently
+   hands the middleware `NullLogger.Instance` and log assertions are impossible. Add a small
+   in-harness `ILoggerProvider`/`ILogger` recording `(LogLevel, string)` pairs and a
+   `Run(..., collectLogs: true)`-style parameter that registers it in the `ServiceCollection`
+   **before** `UseSpaPrerendering` (the logger is resolved at registration time, not per request).
+   No new package: `ILogger`, `ILoggerFactory` and `LoggerFactory` all come from the existing
+   `Microsoft.AspNetCore.App` framework reference — do **not** pull in
+   `Microsoft.Extensions.Diagnostics.Testing`/`FakeLogger` for this.
+4. **`RecordingBootModuleBuilder : ISpaPrerendererBuilder`** with a `BuildCount`, plus a way to pass
+   `options.BootModuleBuilder` through `Run` (a `configureOptions` parameter). Returns a completed
+   task — asserting on a count is a better failure mode than a never-completing task, which would
+   hang the run instead of failing it.
+
+### 6.2 New class `RequestMethodGateTests`
+
+| Test | Asserts | Fails today? |
+|---|---|---|
+| `A_head_request_keeps_the_full_content_length_it_was_given` | HEAD + `StaticFileHead(547)` → `Response.ContentLength == 547`, client body empty. | **Yes** — currently 0. This is the shipped regression, pinned. |
+| `A_head_request_does_not_reach_the_prerenderer` | HEAD + `HtmlPage(index)` (a pipeline that *does* write a body, so the empty-template guard cannot be what saves us) → `Service.WasCalled == false`, `ExplodingNodeServices` never throws, client body byte-identical to the input. | **Yes** — today the service is called. This is the test that pins the *gate* rather than the guard. |
+| `A_head_request_does_not_log_a_warning` | HEAD + `StaticFileHead(547)` with the collecting logger → no entry at `LogLevel.Warning`; exactly one `Debug` entry naming the method. | **Yes** — today one Warning per HEAD. |
+| `A_head_request_does_not_wait_for_the_bootmodule_build` | HEAD + `RecordingBootModuleBuilder` → `BuildCount == 0`. | **Yes** |
+| `A_post_request_is_passed_through_without_prerendering` | POST + `HtmlPage(index)` → `WasCalled == false`, body and `ContentLength` unchanged. | **Yes** |
+| `An_options_request_does_not_wait_for_the_bootmodule_build` | OPTIONS + `RecordingBootModuleBuilder` → `BuildCount == 0`. | **Yes** — the PRD's stated G5 cost. |
+| `A_get_request_is_still_prerendered` | Control: default (GET) + `HtmlPage` → `WasCalled == true`, `BuildCount == 1`. Guards against an inverted gate and against the harness default being lost. | No (passes today too — that is the point) |
+| `Does_not_rewrite_the_content_length_of_a_bodyless_response` — `[Theory]` over `204`, `205`, `304` | GET, `ContentLength` declared, no body → `ContentLength` preserved. | **Yes** — currently rewritten to 0. Covers §2.2's D3 on a path the gate cannot reach. |
+
+### 6.3 Existing tests
+
+- `Reconciles_a_declared_content_length_with_the_empty_body_it_passes_through` — **left untouched and
+  still passing** (body-bearing `200`, GET via the harness default). It keeps its role as the pin for
+  the synthetic-token path and gains a second one: if the harness's GET default is ever lost, it
+  fails.
+- Every other test in `OriginalHtmlCaptureTests` / `AbortedRequestTests` /
+  `PrerenderCancellationTests` — unchanged, and passing *because* of harness addition 1. Worth
+  stating in the PR body: their green status depends on that one line.
+
+---
+
+## 7. Release impact (D6)
+
+**Recommendation: supersede with 10.7.1. Do not pull 10.7.0.**
+
+Severity, proportionately:
+
+- **Who is affected:** only clients issuing a `HEAD` to a prerendered SPA route on 10.7.0. In
+  practice: uptime and health probes, link checkers, some CDN/reverse-proxy revalidation, crawlers.
+  Browsers do not `HEAD` a document navigation.
+- **How badly:** the HEAD reports `Content-Length: 0` with a `200` and `text/html`. A probe checking
+  for a 200 still passes. A checker that asserts a non-zero length, or a cache that stores a
+  zero-length entry for the route, misbehaves. **No GET is affected**, so no user-facing page is
+  broken by it — and #79's guard simultaneously *fixed* a live HEAD defect that had been producing an
+  outright `NG05104` (a 500) for every HEAD before it. Net, HEAD handling on 10.7.0 is better than
+  on 10.6.x, just still wrong.
+- **Contrast with #80's `Range` defect**, which is in the same release train: that one produces real
+  500s on GETs, several times per hour, in the reporter's production. It is the reason for the
+  release; the HEAD item rides along.
+
+Pulling 10.7.0 would strand the abort/decode fixes it carries (a strictly larger user-facing win)
+and break restores for anyone already pinned, to remedy a wrong header on a method browsers do not
+use. Not proportionate.
+
+Suggested PR-body wording:
+
+> Also fixes a regression introduced in 10.7.0 (#79): `PassThroughAsync` reconciled `Content-Length`
+> unconditionally, so a `HEAD` to a prerendered SPA route answered `200 text/html` with
+> `Content-Length: 0` instead of the template's real length — a HEAD must report what the equivalent
+> GET would (RFC 9110 §9.3.2), and Kestrel does not catch it because `VerifyResponseContentLength`
+> skips HEAD. Prerendering is now gated to `GET`, which fixes it at the source: a `HEAD` (or `POST`,
+> or `OPTIONS`) no longer enters the capture, no longer blocks on the SSR bundle build, and no longer
+> logs a warning per request. The reconciliation itself is additionally narrowed to responses that
+> can carry a body, so a `204`/`205`/`304` keeps its declared length.
+>
+> HEAD-only impact, GETs unaffected; 10.7.0 does not need pulling, 10.7.1 supersedes it. Behaviour
+> change to release-note: a consumer middleware registered inside the SPA callback that answered a
+> non-GET with `text/html` was previously prerendered and now is not.
+
+Also update, in the same PR (one PR, per the repo's convention): the Prerendering README's
+prerendering-behaviour section, to state that prerendering applies to `GET` only and what a `HEAD`
+now returns.
+
+---
+
+## 8. Open points for the maintainer
+
+1. **[shared] The harness GET default** is the one edit both workstreams need in the same region;
+   land it once.
+2. **[shared] The empty-guard `204`/`205` Debug refinement** (§4) sits in the other workstream's file
+   region — take it or leave it, but decide once.
+3. **`TRACE`/`OPTIONS` niceties** are out of scope: the gate passes them through, and what happens
+   next (the `SpaDefaultPageMiddleware` throw) is pre-existing behaviour this PR does not change.

--- a/docs/SOLUTION-range-template-gate.md
+++ b/docs/SOLUTION-range-template-gate.md
@@ -1,0 +1,605 @@
+# SOLUTION: the template-validity gate (issue #80 and its class)
+
+Scope of this document: `canPrerender`, `RemoveConditionalRequestHeaders`, the capture decode, and
+the completeness guard that replaces `string.IsNullOrWhiteSpace`. **Out of scope and owned
+elsewhere:** `PassThroughAsync`'s `ContentLength` reconciliation (the shipped HEAD regression) and
+the request-method gate. Where a decision here touches those, it is flagged as a coordination note,
+never as a change.
+
+Input: `docs/PRD-Prerendering-Range-Requests.md` (mechanism, reproduction, breadth survey) and
+`docs/PRD-Prerendering-Aborted-Requests.md` + `docs/SOLUTION-defect2-abort.md` for the established
+contract. Code read: `MintPlayer.AspNetCore.SpaServices.Prerendering/Prerendering/SpaPrerenderingExtensions.cs`
+(current), `Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs`,
+`Tests/Prerendering/SpaPrerenderingExtensionsTests.cs`, `Tests/Prerendering/RangeReproTests.cs`,
+`Internals/LoggerFinder.cs`.
+
+---
+
+## 0. The shape of the decision
+
+`canPrerender` today asks two questions — 2xx, and `text/html` — and infers *"this capture is the
+complete representation the client would otherwise have received."* Neither question is about
+completeness. The gate is therefore restructured as one predicate with a name that states the
+inference it is actually making:
+
+```
+IsCompleteRepresentation(response)  ==  status is exactly 200
+                                     && no Content-Range response header
+                                     && Content-Encoding absent or identity
+                                     && (ContentLength not declared || captured == declared)
+```
+
+plus, after the decode, two content-level checks (valid UTF-8; no U+0000) and one *warning-only*
+structural observation. `IsHtmlContentType` is unchanged. `IsSuccessStatusCode` **stays** — it is
+still what the post-`OnSupplyData` re-check at line 225 needs (see §2).
+
+Everything above is app-agnostic: no check depends on what the SPA's markup looks like.
+
+---
+
+## 1. Strip `Range`, narrow the status check, or both?
+
+**Both. The PRD's defence-in-depth argument is confirmed, and it is stronger than the PRD states.**
+
+- The strip is the *causal* fix: it removes the request-side input that makes downstream produce a
+  partial representation at all. It is exactly why `If-None-Match` is already stripped — we strip
+  the headers whose whole purpose is to make the server return something other than the full
+  entity. `Range` is the last member of that family still present, and the omission is plainly an
+  oversight, not a decision.
+- The status/framing narrowing is the *containment* fix, and it is not hypothetical. `SpaProxy`
+  forwards every request header except `Connection` and `CopyProxyHttpResponse` copies status and
+  `Content-Type` verbatim, so a dev server (or any upstream behind a consumer's own proxy
+  middleware) that answers 206 for its index document reproduces #80 through a path our header
+  surgery never touches. A consumer middleware inside `next()` can also produce a 206 that no
+  request header of ours explains.
+
+Neither alone is sufficient: the strip cannot reach a producer that never looks at our request, and
+the narrowing alone would leave us *asking* for a 206 on every bot request and then throwing the
+answer away — turning a 500 into a needless pass-through of a one-byte body when a full page was
+available and wanted.
+
+**The PRD's finding on `If-Range` is confirmed and is the decisive detail.** `ComputeIfRange` is the
+only code path in `StaticFileContext` that can clear `IsRangeRequest` after `ComputeRange` has
+parsed it. By stripping `If-Range` and leaving `Range`, we removed the only cancel and kept the
+trigger — our own header surgery makes the 206 *more* likely than it would be without us. Stripping
+`Range` restores the invariant the method was written for; there is no case for restoring `If-Range`
+instead (that would make behaviour depend on the client's etag, i.e. non-deterministic).
+
+### Restore `Range` after the capture? **No.**
+
+The `Accept-Encoding` restore is not symmetry — it is **functionally load-bearing**, and reading the
+code makes the asymmetry principled rather than sloppy:
+
+- `Accept-Encoding` is restored inside the `finally` (lines 139-142), i.e. *before*
+  `ServePrerenderResult` writes the prerendered body to the real `Response.Body`. Any compression
+  middleware registered **upstream** of `UseSpaPrerendering` makes its decision at first write —
+  which, on the prerendered path, happens after `next()` has returned. If the header were still
+  missing at that moment, prerendered responses would silently never compress while every other
+  response did. The restore is required for correctness of the outbound response.
+- `Range` has no such consumer. Nothing between the capture and the wire reads it: we do not, and
+  must not, produce a 206 ourselves (see the PRD's non-goal — a per-request generated body has no
+  stable byte range). Restoring it would restore a value that nothing can act on except, in the
+  worst case, a consumer's own middleware upstream of us deciding to slice our prerendered output.
+
+So: strip `Range` alongside the conditional headers, in `RemoveConditionalRequestHeaders`, and do
+not restore it — the same treatment the four `If-*` headers already get, which keeps that method
+internally consistent.
+
+**Trade-off, stated:** a client that asked for bytes gets a whole page. That is permitted (a server
+MAY ignore `Range`), it is the only coherent option for generated output, and it is invisible to
+browsers (Chromium sends no `Range` on document navigation — verified in the PRD). The cost lands on
+CDNs and scanners, which handle a 200 for a range request routinely. **Release-note it.** A second,
+smaller cost: the code comment on `RemoveConditionalRequestHeaders` must be rewritten — it currently
+explains only the 304, and the `Range` line needs the `If-Range` reasoning above recorded next to
+it, or the next reader will "restore symmetry" by re-adding `If-Range`.
+
+---
+
+## 2. If the status check narrows, to what?
+
+**`200` exactly, *and* reject a `Content-Range` response header. Both, for different failure
+modes.**
+
+`200` exactly is the invariant: of the 2xx codes, only 200 promises "the body is the complete
+representation of the target resource". Enumerating the rest confirms there is nothing to keep:
+201/202/203 have no producer on this path and none of them promises the representation of the
+requested resource (203 explicitly disclaims it), 204/205 must have no body, 206 is the defect, 207
+is WebDAV, 226 needs delta encoding. Nothing legitimate is lost.
+
+The `Content-Range` check is not redundant with it — it catches the one shape the status check
+cannot: **a consumer's middleware that rewrote the status while leaving the framing headers behind.**
+`UseStatusCodePagesWithReExecute` and `UseExceptionHandler` both rewrite status inside `next()`, and
+`ExceptionHandlerOptions.StatusCodeSelector` is an unconstrained `Func<Exception,int>`; a
+re-executed action returning `Ok()` produces exactly `200 + stale Content-Range`. It also costs one
+header lookup.
+
+**Which fails more safely with an unknown consumer middleware?** `200`-exactly, decisively. "2xx
+minus `Content-Range`" fails *open* on every status whose semantics we have not thought about — it
+accepts a 206 whose producer forgot `Content-Range` (a proxy that copies status but not headers:
+precisely the dev-proxy shape), and it accepts future/vendor 2xx codes by default. `200`-exactly
+fails *closed*: an unknown status means pass-through, which is always a valid outcome because the
+captured bytes are exactly what the client would have received. Using both gives the closed default
+plus one extra rejection for a status we would otherwise trust.
+
+**The rationale is framing, not truncation.** The PRD's point stands and must be recorded in the
+code comment, because it is counter-intuitive enough to be "fixed" later: `bytes=0-` yields a 206
+carrying the *complete* document, so "206 implies truncated" is false — and rejecting it is still
+correct, because `Content-Range` and the range unit describe a byte range of a specific entity, and
+prerendering replaces the entity. There is no honest way to emit `Content-Range: bytes 0-546/547`
+over a 25 KB rendered page. A 206 is therefore un-prerenderable *whatever* its body contains, and
+that is a statement about framing.
+
+### Not narrowed: the post-`OnSupplyData` re-check (line 225)
+
+`IsSuccessStatusCode` stays there, unchanged. The two checks ask different questions: the pre-gate
+asks *"is this capture the complete representation?"*, the post-check asks *"does the prerendering
+service still want us to render a body, or has it redirected / errored?"*. The template has already
+been validated by then; narrowing the second check to 200 would newly reject a service that
+deliberately sets, say, a 201 or 202 on its prerendered response, for no gain. `IsSuccessStatusCode`
+and `IsSuccessStatusCodeTests` therefore both survive.
+
+---
+
+## 3. The layered completeness check
+
+### 3.1 Framing invariants — **include**
+
+Exactly four, all decisive and app-agnostic:
+
+| # | Invariant | What it closes | False-positive surface |
+|---|---|---|---|
+| F1 | status == 200 | A2 (206 from any producer), 416 and every other status | none (§2) |
+| F2 | no `Content-Range` | A2 via a status-rewriting middleware | a middleware that sets `Content-Range` on a genuinely complete 200 — a protocol error either way |
+| F3 | `Content-Encoding` absent or `identity` (case-insensitive, single value) | B1 (`MapStaticAssets` Brotli variants, or any consumer that encodes inside `next()`) | a consumer explicitly declaring `identity` is accepted; anything else is genuinely undecodable by `Encoding.UTF8.GetString` |
+| F4 | `ContentLength` not declared, **or** captured bytes == declared bytes | B5, and mid-copy truncation with no cancelled token | the hard call — §3.1.1 |
+
+F3 deserves one note: the `Accept-Encoding` strip is described in the current code as a precaution,
+and it has never had a check behind it. F3 is that check. It is also the cheapest of the four — a
+header read — and it is the only thing standing between a compressed capture and
+`Encoding.UTF8.GetString` on Brotli bytes.
+
+**F1-F3 are what actually close #80.** F4 closes neither #80 nor anything the abort check already
+covers; it is included on its own narrow merits, argued below.
+
+Method (GET) belongs in this set conceptually, and is deliberately absent here: it is the other
+agent's decision, and F1-F4 must not silently pre-empt it. Whoever lands the method gate should add
+it to the same predicate.
+
+#### 3.1.1 F4: declared-vs-captured. The hard call, reconciled
+
+`SOLUTION-defect2-abort.md` §2 **rejected** this comparison as control flow, in three arguments.
+Taking them in turn, honestly:
+
+> "It has legitimate false positives inside `next()`. `UseWebMarkupMin` turns a 547-byte file into a
+> 456-byte template. Any response-transforming middleware legitimately makes buffer length ≠ the
+> `ContentLength` some inner component set."
+
+**This premise does not survive scrutiny, and it is the reason the rejection can be reversed.** The
+missing observation is that *the same mismatch would be fatal outside our capture*. Kestrel enforces
+declared-vs-written in both directions: too many bytes throws on the write, too few throws at
+response completion (`Response Content-Length mismatch: too few bytes written` — the very exception
+the previous PRD chased in its §"Follow-up found by the verification"). A transforming middleware
+that shrank the body while leaving a stale larger `Content-Length` would therefore break **every**
+response it touched on every non-prerendered route in the application. `UseWebMarkupMin` is widely
+deployed and does not do this; whatever it does with the header (update it to the minified length,
+or remove it and let the response go chunked), the post-transform state is necessarily *consistent*,
+because an inconsistent one is unshippable. Our `MemoryStream` is the only thing in the pipeline that
+would have masked it.
+
+So `ContentLength.HasValue && captured != declared`, observed at the moment `next()` returns, means
+one of exactly two things:
+
+1. the capture is short of what downstream believed it wrote — truncation, or bytes still sitting in
+   an unflushed `PipeWriter` (B5); or
+2. the application has a latent framing bug that Kestrel would reject on any route we are not
+   capturing.
+
+Neither is a template. In both cases skipping prerendering is right.
+
+> "It is absent exactly where it would be needed. Chunked responses carry no `ContentLength` at all."
+
+**Correct, and unchanged.** F4 is additive, never a substitute. It is silent on the whole chunked /
+dev-proxy family, which is precisely why the `HasValue` guard is part of the invariant rather than a
+regrettable limitation: no declared length, no claim, no rejection.
+
+> "The case it would catch is already covered causally — truncation comes from an abort, and the
+> abort check catches it at the source."
+
+**Mostly true, and it is why F4's unique value is narrow.** The abort check (`RequestAborted`) fires
+first and covers mid-copy truncation on a cancelled token. F4's residual, non-overlapping coverage
+is: truncation with **no** cancelled token — an upstream socket error inside the dev proxy's copy, a
+downstream stream that stops early, and B5's `PipeWriter` bytes that never reach the buffer. Real,
+reachable, and today entirely undetected.
+
+**Decision: include F4, in one direction only, and pin it with a test.**
+
+- Fire only when `ContentLength.HasValue && outputBuffer.Length < context.Response.ContentLength`.
+  A *short* capture is the failure mode; captured-greater-than-declared is unreachable through
+  anything Kestrel would have accepted, and rejecting it buys nothing while adding a second way to
+  be wrong. Asymmetric on purpose.
+- Log it at **Warning**, with both numbers (§5). This is what makes the reversal defensible: the
+  previous rejection's real objection was not "the signal is wrong", it was *"a false positive means
+  prerendering silently stops working, which is far worse and much harder to diagnose."* That
+  objection was correct against an **unlogged** check. A Warning naming the path, the declared
+  length and the captured length turns a silent regression into a one-line diagnosis, and the
+  middleware now has logging infrastructure it did not have when that call was made.
+- Pin the transformer contract with a committed test (§6, test 17): a wrapper inside `next()` that
+  shrinks the body **and** updates `ContentLength` must still prerender. If the premise above is
+  ever wrong for a real consumer, that test is where the counter-example lands, and F4 is one `&&`
+  clause to remove.
+
+**Should the comparison move out of `PassThroughAsync`? No.** A3's "the signal is computed and used
+backwards" is resolved by *adding* the conclusion at the gate, not by relocating the arithmetic. The
+reconciliation in `PassThroughAsync` still has a job on the abort path (defining out of existence
+the synthetic-token mismatch documented in the previous PRD), and it applies on paths the gate never
+sees. Both may read `ContentLength`; that is not duplication worth removing.
+
+**Coordination note for the other agent (not a change requested here):** on an F4 rejection the
+capture is passed through, and `PassThroughAsync` will then reconcile the declared length *down* to
+the captured bytes — right for a genuine truncation (we cannot invent bytes we do not have), and the
+exact mechanism behind the shipped HEAD regression. Whatever makes reconciliation conditional for
+HEAD must not accidentally disable it for the truncation case; a HEAD-shaped condition (no body
+expected) rather than a "buffer is empty" condition keeps both correct.
+
+### 3.2 Decode integrity — **include, but not as the PRD framed it**
+
+The PRD offers "reject U+FFFD / U+0000, or decode with `throwOnInvalidBytes: true`". Both forms have
+a defect, and there is a third that has neither.
+
+- `throwOnInvalidBytes` reintroduces exactly what the previous PRD deliberately avoided: a throw on
+  the request path, from a partial UTF-8 sequence in a truncated capture. It also destroys the
+  diagnostic — we cannot log the template head of a string we failed to produce.
+- Rejecting the *decoded* U+FFFD conflates two different things: invalid bytes (a corrupt capture)
+  and a legitimate template that happens to contain a literal replacement character in valid UTF-8.
+  Rare in an `index.html`, but it is a false positive that silently disables prerendering, and we
+  have just spent §3.1.1 arguing that those are the expensive kind.
+
+**Decision: keep the lenient decode exactly as it is, and validate the bytes separately.**
+
+1. Before decoding, `System.Text.Unicode.Utf8.IsValid(buffer)` on the captured span (available on
+   `net10.0`, which both projects target; no allocation, no exception, no fallback plumbing). Invalid
+   → reject at Warning. This is precise: it distinguishes "these bytes are not UTF-8" from "this
+   text contains U+FFFD", which no post-decode inspection can do.
+2. After decoding, reject if the template contains **U+0000**. This is B2 verbatim: UTF-16-encoded
+   markup is *valid* UTF-8 byte-wise for the ASCII half and decodes to `<\0!\0d\0…`, and
+   `char.IsWhiteSpace('\0')` is `false`, so it sails past the existing empty guard into NG05104. A
+   NUL is also not representable in a conforming HTML document (the HTML parser replaces it), so
+   there is no legitimate template to break. Note this check would *also* have caught the
+   pre-#79 `GetBuffer()` padding defect — cheap corroboration that it discriminates real corruption.
+3. Do **not** reject on U+FFFD. Pinned by a test (§6, test 15) so it is not "tightened" later.
+
+The lenient decode therefore stays lenient, and keeps its stated reason (a truncated capture must
+not throw); the strictness moves to a check that can report instead of throw. Between them, F3 and
+these two close B1 and B2 without knowing anything about the app.
+
+### 3.3 Structural HTML as a warning — **include, at two levels**
+
+Include, and keep it strictly non-rejecting. The PRD's honesty about the limit is right: domino
+normalizes a bare `<app-root></app-root>` into a full document and the render succeeds, so a fragment
+template is a legitimate — if unusual — deployment, and a hard rejection would turn a working
+application into 500s for no proven gain. The measurements settle it independently: `bytes=0-99`
+*starts with* `<!doctype html><html lang="en">` and would pass any structural test, so this layer
+would not have caught #80 even if it were a rejection. It is a diagnostic, and should be honest about
+being one.
+
+**What is checked:** the decoded template contains `<html` **and** `</html>`, both ordinal
+case-insensitive. Nothing more — no doctype requirement (legitimate templates omit it, and a
+doctype check demonstrably fails on `bytes=0-99` anyway), no `<body>`, no counting.
+
+**Level:** `Warning` **once per pipeline**, plus `Debug` on every occurrence. The reasoning:
+
+- Warning-every-time is unacceptable — a fragment deployment would emit a warning per request
+  forever, and the previous PRD's HEAD lesson (a Warning with a benign cause is worse than no
+  Warning) applies verbatim.
+- Debug-only is what the reporter already had, and it failed: they had to hand-build their own
+  logging because nothing was visible at default levels. That is the problem being solved.
+- Once-per-pipeline gets the diagnostic in front of anyone reading logs at default level on the
+  first affected request, then goes quiet. The flag is a closure-scoped `int` with
+  `Interlocked.Exchange` next to the existing captured `logger`/`options` — no static state, scoped
+  to the `UseSpaPrerendering` call, which is the right lifetime.
+
+**Message content:** path, template length in characters, and the **first 200 characters** of the
+template with CR/LF collapsed to spaces so it stays one log line. That is precisely the diagnostic
+the reporter had to build by hand, and it is the only place in this design where template content is
+logged (see §5 on why that matters).
+
+### 3.4 Guessing the root element — **exclude**
+
+Confirmed, without reservation. `<app-` prefix matching, "contains a hyphenated custom element",
+"has a child of `<body>`" all fail on real applications and each one converts a working deployment
+into a 500. `Contains("<our-app")` is correct **for the reporter** and correctly lives in *their*
+`OnSupplyData`, where it already does its job.
+
+Also excluded from this PR: the opt-in escape hatch the PRD mentions (a configured root selector or
+a template predicate on `SpaPrerenderingOptions`). It is the only sound route to a strong check, and
+it should be recorded as such — but no consumer has asked for it, #80 is closed by F1-F3, and it is
+new public API surface that would need documenting and supporting. This is a genuine non-need, not
+work deferred to keep the diff small. It is the answer if B3 (§7) is ever reported for real.
+
+---
+
+## 4. What the response should be on rejection
+
+**Confirmed: pass the capture through unchanged, on every rejection path. No new behaviour.**
+
+For a 206 this is not a compromise, it is the right answer: the client asked for a byte range and
+receives exactly the bytes downstream produced, with its own `Content-Range` and `Content-Length`
+intact and mutually consistent. We are declining to *prerender*; we are not declining to *serve*.
+The same holds for 416, for a compressed capture (the client's own `Accept-Encoding` asked for it —
+note our strip only applies to the sub-request, and F3 rejections can only arise from a producer
+that encoded regardless), and for a truncated capture (passing the bytes on is strictly better than
+substituting a page we cannot build).
+
+**On the leaked `Content-Range` / `Content-Length: 1`:** they stop leaking, and not because we strip
+them. Today those headers ride onto the 500 because prerendering *proceeds*, NG05104 throws from
+line 239, and `UseExceptionHandler` re-enters a pipeline whose response headers were set by the 206.
+Once the gate rejects, there is no throw, no error page, and no 500 — the headers stay on the 206
+they correctly describe. **Do not strip `Content-Range` on the pass-through path**: on a legitimate
+206 from a consumer's middleware, removing it would corrupt a correctly framed response and is the
+one way this fix could make things worse.
+
+One consequence worth recording in the code comment: after the `Range` strip, a 206 reaching the
+gate is *anomalous* — nothing in the request we forwarded asked for one. That is the justification
+for logging framing rejections at Warning rather than Debug (§5), and it is a genuine behaviour
+difference from today, where the 206 is expected because we asked for it.
+
+---
+
+## 5. Logging
+
+Design constraints taken from the two PRDs: the reporter had to build their own logging to diagnose
+#80 at all; the empty-template Warning currently fires on every benign HEAD and is therefore already
+teaching consumers to ignore this category; and template content in logs is not free.
+
+**One message template per rejection cause**, not a shared template with a `{Reason}` field — the
+fields differ per cause, and log-based alerting keys on the template. Every line names the path and
+says "Skipping prerendering", matching the two existing lines.
+
+| Cause | Level | Fields |
+|---|---|---|
+| Partial / non-200 framing (F1, F2) | **Warning** | `{Path}`, `{Method}`, `{StatusCode}`, `{ContentRange}` |
+| `Content-Encoding` (F3) | **Warning** | `{Path}`, `{ContentEncoding}` |
+| Short capture (F4) | **Warning** | `{Path}`, `{CapturedBytes}`, `{DeclaredBytes}` |
+| Invalid UTF-8 / NUL in template (§3.2) | **Warning** | `{Path}`, `{CapturedBytes}`, `{ContentType}`, `{TemplateHead}` |
+| No `<html>`/`</html>` (§3.3, non-rejecting) | **Warning** once, then `Debug` | `{Path}`, `{TemplateLength}`, `{TemplateHead}` |
+| Aborted request (existing) | `Debug` | unchanged |
+| Empty template (existing) | `Warning` | unchanged — but see the coordination note below |
+
+**Warning is the right level for all five new lines**, and this is a considered position given the
+HEAD lesson. Each has no benign cause *after* this fix: we no longer send `Range`, we no longer send
+`Accept-Encoding`, a declared length that does not match what was written is a framing bug
+somewhere, and a template that is not valid UTF-8 or contains NUL is corrupt. Prerendering silently
+not happening is the failure mode consumers cannot diagnose, so each of these must be visible at
+default level. The one non-rejecting line is the one that gets the once-only treatment, precisely
+because it is the one with a benign cause.
+
+**Field-by-field justification** (rather than logging everything everywhere):
+
+- `{Path}` — every line. Without it the operator cannot tell which route stopped prerendering.
+- `{Method}` — framing line only. It is what separates "a bot sent `Range`" from "a monitoring probe
+  sent HEAD", and it is part of the framing set even though the method gate itself is not this
+  agent's decision. Not on the other lines, where it does not discriminate anything.
+- `{StatusCode}` — framing line only. It is the rejected value.
+- `{ContentRange}` — framing line only, and it is **the** field that would have identified #80.
+  `bytes 0-0/547` says in one token: this is range traffic, this is the slice, and the entity is 547
+  bytes. Nothing else in the response says that.
+- `{ContentEncoding}` / `{CapturedBytes}` / `{DeclaredBytes}` / `{ContentType}` — each only on the
+  line whose rejection they explain. `ContentType` earns its place on the decode line specifically
+  because B2 is a charset problem and the declared charset is the first thing to look at.
+- `{TemplateHead}` (first 200 chars, newlines collapsed) — **only** on the two content-level lines.
+  Deliberately *not* on the framing lines: there the headers fully explain the rejection, and an
+  `index.html` can carry CSP nonces, inline bootstrap configuration and build metadata that has no
+  business being duplicated into a log store on every bot request.
+- **User-Agent — rejected**, against the PRD's suggestion. Method + status + `Content-Range` already
+  identifies #80 in one reading; UA adds request-identifying data to a library's log output for no
+  additional diagnostic, and any consumer who wants it already has request logging.
+
+**What would have identified #80 in one reading.** This line, at default level:
+
+> `Skipping prerendering of /person: the captured response is a partial representation
+> (GET, status 206, Content-Range "bytes 0-0/547").`
+
+**Log category.** `LoggerFinder.GetOrCreateLogger(applicationBuilder, nameof(UseSpaPrerendering))`
+produces the category `"UseSpaPrerendering"`. That is not filterable through the conventional
+`Logging:LogLevel:<namespace>` configuration, so a consumer cannot turn this middleware's Debug lines
+on without turning on everything. **Recommendation: change the category to the full type name**
+(`MintPlayer.AspNetCore.SpaServices.Prerendering.SpaPrerenderingExtensions`). It is a one-line change
+in the `UseSpaPrerendering` callsite, it makes every line in the table above configurable, and it is
+a small breaking change for anyone filtering on the old string — so it needs a release-note line.
+Flagged as a recommendation rather than folded in silently, since it also affects the two existing
+lines the other agent is touching.
+
+**Coordination note (not a decision here):** the existing empty-template Warning and its "There is
+no known benign cause" comment are demonstrably wrong for HEAD. That belongs to the method-gate
+agent. If a method gate lands, the empty guard's Warning becomes correct again and the comment can
+stay; if it does not, the level must drop. Either way, the empty guard itself stays — it is the only
+check that covers a chunked empty capture, where F4 is silent.
+
+---
+
+## 6. Tests
+
+### What to keep from `Tests/Prerendering/RangeReproTests.cs`
+
+The scratch file is deleted; five of its seven cases move into the committed suite with inverted
+assertions, and two are dropped:
+
+| Scratch case | Disposition |
+|---|---|
+| `Repro_1` (`bytes=0-0` → `originalHtml == "<"`) | **Keep, inverted** → test 1 |
+| `Repro_2` (`Range` survives the strip) | **Keep, inverted** → test 5 |
+| `Repro_3` (`Range` + full 200 still prerenders) | **Keep as-is** → test 7 |
+| `Repro_4` (`bytes=0-99`) | **Keep, inverted** → test 2, and it is load-bearing |
+| `Repro_5` (`bytes=100-200`) | **Keep, inverted** → test 3 |
+| `Repro_6` (multi-range → 200) | **Keep as a control** → test 9 |
+| `Repro_7` (416) | **Keep as a control** → test 8 |
+
+Its `PartialContent(slice, from, to, total)` helper is exactly the `StaticFileMiddleware` 206
+contract (status, the file's own `Content-Type`, slice-length `ContentLength`, `Content-Range`,
+`Accept-Ranges`) and should move onto `PrerenderingHarness` next to `AbortedStaticFile`. Note it sets
+`ContentLength` to the *slice* length, faithfully — which is why **F4 does not catch #80** and F1/F2
+must.
+
+### Committed suite
+
+New class `RangeAndTemplateValidityTests` in
+`Tests/Prerendering/SpaPrerenderingMiddlewareTests.cs`, alongside `AbortedRequestTests`. Every test
+below fails on the current branch unless marked *(control — passes today)*.
+
+**Framing: partial content**
+
+1. `Does_not_prerender_a_single_byte_partial_response` — `PartialContent(bytes[..1], 0, 0, 547)`,
+   request carries `bytes=0-0`. Asserts `WasCalled == false`; client body is that one byte; status
+   still 206; `Content-Range` still `bytes 0-0/547`; `ContentLength == 1`. The reported symptom,
+   inverted, plus §4's promise that the framing headers are left intact.
+2. `Does_not_prerender_a_markup_shaped_partial_slice` — `bytes=0-99` of a 20 KB page whose first 100
+   bytes are `<!doctype html><html lang="en">…`. **Load-bearing:** the test body must first
+   `Assert.StartsWith("<!doctype html><html lang=\"en\">", slice)` so the file itself records *why*
+   a plausibility check cannot work, then assert `WasCalled == false`. Without that first assertion
+   the test looks like a duplicate of test 1 and invites someone to delete it.
+3. `Does_not_prerender_a_mid_document_partial_slice` — `bytes=100-200`, no `<html` in the slice at
+   all. Same assertions.
+4. `Does_not_prerender_a_two_hundred_that_still_carries_a_content_range` — 200, `text/html`,
+   complete body, stale `Content-Range`. Pins F2 independently of F1, i.e. the status-rewriting
+   middleware shape. Fails today.
+
+**Request-side strip**
+
+5. `Strips_the_range_header_before_the_capture` — inner pipeline records
+   `Request.Headers[Range]`; asserts it is absent, and that `If-Range` is absent too (the existing
+   behaviour that made the range un-cancellable).
+6. `Does_not_restore_the_range_header_after_the_capture` — asserts `Range` is still absent on the
+   context after the pipeline completes, while `Accept-Encoding` **is** restored. One test, both
+   halves, because the asymmetry is the decision and a test that only checks one half would be
+   "corrected" by the next reader.
+7. `Prerenders_normally_when_a_range_request_is_answered_with_a_full_two_hundred` *(control — passes
+   today)* — `Range` present, downstream answers 200 with the whole page: still prerenders, full
+   template.
+
+**Controls that a status-check change must not break**
+
+8. `Does_not_prerender_an_unsatisfiable_range_response` *(control)* — 416 + `Content-Range: bytes
+   */547`. Passes today via `IsSuccessStatusCode`; must keep passing via F1. Its point is that a
+   future "let's accept 2xx again" change cannot quietly start accepting it.
+9. `Prerenders_a_multi_range_request_that_downstream_ignored` *(control)* — `bytes=0-0,2-2`, 200 with
+   the whole file.
+10. `Prerenders_a_malformed_range_request_that_downstream_ignored` *(control)* — `Range: bananas=1-2`
+    (and a second case, `bytes=abc`), 200 with the whole file. ASP.NET Core ignores both, and the
+    PRD's note that neither `RangeHelper.ParseRange` nor `RangeHeaderValue` validates the *unit* is
+    why `items=0-0` is worth one `[Theory]` row here rather than a comment.
+
+**Content-Encoding (B1)**
+
+11. `Does_not_prerender_a_capture_with_a_content_encoding` — 200, `text/html`,
+    `Content-Encoding: br`, body = arbitrary non-UTF-8 bytes. `WasCalled == false`; body passed
+    through byte-for-byte.
+12. `Prerenders_a_capture_that_declares_identity_encoding` — `Content-Encoding: identity` (and a
+    `[Theory]` row for `IDENTITY`) still prerenders. Guards F3 against over-firing.
+
+**Decode integrity (B2, §3.2)**
+
+13. `Does_not_prerender_a_capture_that_is_not_valid_utf8` — body = a truncated multi-byte sequence
+    plus real markup, or raw Brotli bytes with no `Content-Encoding`. `WasCalled == false`.
+14. `Does_not_prerender_a_utf16_encoded_template` — B2 verbatim: `Encoding.Unicode.GetBytes(index)`
+    with `Content-Type: text/html; charset=utf-16`. Documents in a comment that
+    `char.IsWhiteSpace('\0')` is `false`, which is why the existing empty guard does not catch it.
+15. `Prerenders_a_template_containing_a_literal_replacement_character` — valid UTF-8 containing
+    U+FFFD as content. **Must prerender.** This is the test that pins the choice of `Utf8.IsValid`
+    over "reject U+FFFD"; without it, someone simplifies the check and introduces the false positive.
+
+**Declared-vs-captured (F4, §3.1.1)**
+
+16. `Does_not_prerender_a_capture_shorter_than_its_declared_content_length` — 200, `text/html`,
+    `ContentLength = 20000`, 8192 bytes written, **not** aborted. `WasCalled == false`. Fails today,
+    and it is the deliberate reversal of `SOLUTION-defect2-abort.md` §2 / that document's test 7.
+17. `Prerenders_a_response_a_transforming_middleware_shrank` — **the regression guard for the hard
+    call.** An inner wrapper inside `next()` sets `ContentLength = 547`, writes a 547-byte page,
+    then minifies to 456 bytes *and updates `ContentLength` to 456* (the `UseWebMarkupMin` shape,
+    modelled on the previous PRD's collateral finding #5). Must still prerender, with the 456-byte
+    template. If F4 ever has to be removed, this is the test that will have failed.
+18. `Prerenders_a_short_chunked_capture_with_no_declared_length` — 200, `text/html`, no
+    `ContentLength`, short body. Must prerender: F4 makes no claim without a declared length.
+19. `Prerenders_a_capture_longer_than_its_declared_content_length` — pins F4's one-directionality.
+    Arguably over-specified; keep it, because "reject on any mismatch" is the obvious simplification
+    and this records that it was declined.
+
+**Structural warning (§3.3)**
+
+20. `Prerenders_a_fragment_template_without_an_html_element` — body is `<app-root></app-root>`.
+    Must **prerender** (`WasCalled == true`), and must log. Requires the harness addition below.
+21. `Warns_once_about_a_fragment_template_and_then_stays_quiet` — two requests through the *same*
+    pipeline; exactly one Warning, and a Debug on both. Pins the closure-scoped flag, including that
+    it is per-pipeline rather than per-process (a second `Run` gets its own Warning).
+
+**Existing tests affected**
+
+- `Still_prerenders_a_partially_captured_template` (line ~506) **keeps passing unchanged** —
+  `HtmlPageInChunks` sets `ContentLength` to the sum of the chunks it actually writes, so
+  captured == declared and F4 is silent. But its comment (*"the reason the abort check is not
+  redundant with the empty-template guard"*) and the entry it pins in
+  `SOLUTION-defect2-abort.md` §2 are now **half wrong**: with a *declared* length, F4 catches that
+  case too. Rewrite the comment to say the abort check remains the only cover for a **chunked**
+  partial, and cross-reference test 16. Leaving it as-is is the single most likely way this decision
+  gets silently reverted later.
+- `IsSuccessStatusCodeTests` — unchanged (§2: the helper survives for the post-`OnSupplyData` check).
+- `RemoveConditionalRequestHeadersTests.Removes_every_conditional_header` — add `Range` to the
+  header set it writes and asserts on; the reflection harness (`SpaPrerenderingReflection`) already
+  exposes the method. Add a matching `[Theory]` unit test for the new
+  `IsCompleteRepresentation`-style helper through the same reflection harness if it is factored as a
+  private static, covering: 200 accepted; 200 + `Content-Range` rejected; 206 rejected; 416 rejected;
+  201/202/203/204/226 rejected; `identity` accepted; `br` rejected.
+
+**Harness additions required** (`PrerenderingHarness`, all small):
+
+- `PartialContent(byte[] slice, long from, long to, long total)` — moved from the scratch file.
+- A log-capturing `ILoggerFactory` registered in the harness's *application* services. Today none is
+  registered, so `LoggerFinder` returns `NullLogger` and **no log assertion is possible anywhere in
+  the suite**. Tests 20-21 need it, and it retroactively makes the two existing log lines from #79
+  assertable. Smallest form: an `ILoggerProvider` collecting `(LogLevel, EventId, string)` into a
+  list, exposed on `Result`.
+- `configureContext` already exists and is sufficient for the request-header cases.
+
+---
+
+## 7. Which Tier-B findings this closes, and which it does not
+
+| # | Closed? | By what, and what remains |
+|---|---|---|
+| **A2** (206) | **Yes, twice** | `Range` strip removes the cause; F1/F2 reject any 206 from a producer we cannot influence (dev proxy, consumer middleware, `FileResult` with `enableRangeProcessing`, `MapStaticAssets`). |
+| **A4** (nothing on the response is inspected) | **Mostly** | `Content-Range`, `Content-Encoding` and the length comparison are now read. `Request.Method` and `Transfer-Encoding` remain unread — method is the other agent's; `Transfer-Encoding` is not observable at this layer under Kestrel and needs nothing. |
+| **B1** (`Content-Encoding`) | **Yes** | F3 rejects it outright, and §3.2's `Utf8.IsValid` catches a compressed capture that arrives with no header at all. The `Accept-Encoding` strip finally has a check behind it. |
+| **B2** (non-UTF-8 charset) | **Yes, in practice** | UTF-16 is caught by the NUL check; any single-byte legacy encoding with a non-ASCII byte is caught by `Utf8.IsValid`. A pure-ASCII page mislabelled `windows-1252` is byte-identical to UTF-8 and needs no catching. The decode stays UTF-8-only by design (honouring the charset on the read side alone would turn visible mojibake into silently wrong bytes). |
+| **B4** (`Response.Clear()` inside the capture) | **Partly, and unchanged by this fix** | `Clear()` wipes headers, so `ContentType` becomes null and `canPrerender` already rejects — that half is covered incidentally. The half where a middleware clears *and* re-sets `Content-Type` is B3 by another name. The stale-tail consequence is already nil thanks to the `TryGetBuffer` decode; the NUL check is a second net under it. |
+| **B5** (unflushed `PipeWriter` writes) | **Partly** | Caught by F4 whenever a `ContentLength` was declared — which is the static-file and most MVC shapes. Not caught on a chunked response, where nothing at this layer can distinguish a short capture from a short page. Document as a known limitation. |
+| **A5** (deferred status codes) | **No, and out of scope** | `SkipPrerendering()` remains the opt-in answer; a third-party status set inside `OnStarting` is undetectable by construction. Unchanged from the previous PRD's decision. |
+| **A1 / A3-HEAD / the method gate** | **Not mine** | F1-F4 are written so the method invariant slots into the same predicate. |
+| **B3** (an error page captured as the template) | **NO. Plainly not caught.** | It is 200, `text/html`, no `Content-Range`, no `Content-Encoding`, `ContentLength` consistent, valid UTF-8, no NUL, and it contains `<html>`/`</html>`. It passes every check in this document — by construction, because it *is* a complete representation; the thing that is wrong with it is that it is the representation of a *different* resource, and no app-agnostic check can see that. It is also the one case in the whole survey that looks perfectly healthy in a log. |
+
+**B3 is therefore a documented known limitation, and the documentation is part of this work:**
+
+1. A note in the Prerendering README: do not register `UseExceptionHandler` or
+   `UseStatusCodePagesWithReExecute` **inside** the `UseSpa`/prerendering callback — the error page
+   lands inside the capture and becomes the SSR template. Worth naming the demo's own commented-out
+   `spa.ApplicationBuilder.UseResponseCaching()` as the invitation to that placement, since it is in
+   this repo and reads as an endorsement.
+2. A note that a consumer who needs a hard guarantee should assert on the template in their own
+   `OnSupplyData` — which is what the reporter's `Contains("<our-app")` does, and it is the correct
+   home for an app-specific check.
+3. The sound in-library fix, if it is ever reported for real, is the opt-in predicate declined in
+   §3.4 — recorded there so the next person does not re-derive it.
+
+---
+
+## Summary of decisions
+
+| # | Decision |
+|---|---|
+| 1 | **Both.** Strip `Range` in `RemoveConditionalRequestHeaders` (the cause) **and** narrow the gate (containment against the dev proxy and consumer middleware). **Do not restore `Range`** — the `Accept-Encoding` restore is functionally required for upstream compression at prerender-write time; `Range` has no consumer after the capture. Record the `If-Range` reasoning in the comment so the strip is not "symmetrised" away. |
+| 2 | **Status exactly 200, *and* reject a `Content-Range` response header.** 200-exactly fails closed on unknown statuses; the `Content-Range` check covers a status-rewriting middleware. Rationale is *framing*, not truncation — a `bytes=0-` 206 carries the whole document and is still un-prerenderable. `IsSuccessStatusCode` stays, for the post-`OnSupplyData` re-check only. |
+| 3 | **Framing invariants F1-F4 included** (200; no `Content-Range`; `Content-Encoding` absent/`identity`; declared length, if present, not greater than captured). **F4 reverses `SOLUTION-defect2-abort.md` §2** on the ground that its central premise — a transformer legitimately leaving a stale `Content-Length` — cannot survive Kestrel's own mismatch enforcement on every non-captured route; the reversal is conditioned on `HasValue`, one-directional, logged at Warning, and pinned by a transformer test. The comparison is **added** at the gate, **not moved** out of `PassThroughAsync`. |
+| 4 | **Decode integrity included, reframed:** keep the lenient decode; validate bytes with `Utf8.IsValid` before decoding and reject U+0000 after. Reject neither U+FFFD-as-content nor by throwing. |
+| 5 | **Structural check included as a warning only** (`<html` + `</html>`): Warning once per pipeline, Debug always, carrying the first 200 characters. Root-element guessing excluded; the opt-in predicate declined as a genuine non-need. |
+| 6 | **Rejection = pass through unchanged, always.** The leaked `Content-Range`/`Content-Length: 1` disappear because there is no longer a 500 to leak onto, not because we strip them — and stripping them is explicitly forbidden. |
+| 7 | **Five new log lines, one template per cause, all Warning**, with per-line fields justified; template head only on the two content-level lines; User-Agent rejected. Recommend changing the log category to the full type name so the lines become filterable. |
+| 8 | **21 committed tests** in a new `RangeAndTemplateValidityTests`, five inherited from the scratch repro (inverted), including the load-bearing `bytes=0-99` case and the 416 / multi-range / malformed-range controls. Three harness additions, one of them a log-capturing `ILoggerFactory` the suite has never had. `Still_prerenders_a_partially_captured_template` keeps passing but its comment must be corrected. |
+| 9 | **Closes A2, A4 (partly), B1, B2, B5-with-a-declared-length. Does not close B3** — an error page captured as the template passes every check by construction, and is documented as a known limitation with a README warning and the opt-in predicate named as the eventual answer. |


### PR DESCRIPTION
Fixes #80, reported by @Reonekot. Thank you again — the diagnosis was right, and it was right about a bug that survived #79.

Also fixes a regression **#79 introduced and shipped in 10.7.0**, found while investigating this one.

Every bug below is listed with its symptom, its cause, the fix, and the regression test that covers it. All six packages go to **10.7.1** in lockstep, matching the policy set in #79.

---

## 1. A `Range` request made the prerenderer render a one-byte template

**Symptom.** `originalHtml == "<"` — the `<` of `<!doctype html>` — reaching `OnSupplyData`, then `NG05104` and an HTTP 500. Reported as a few times an hour in production. Deterministic, not a race, which is why it reproduced consistently.

**Cause.** Three conditions, all of which held:

1. `RemoveConditionalRequestHeaders` stripped `If-Match`, `If-Modified-Since`, `If-None-Match`, `If-Unmodified-Since` and `If-Range` — but **not** `Range`.
2. `IsSuccessStatusCode` was `>= 200 && < 300`, so `206 Partial Content` satisfied `canPrerender`. A 206 *does* carry the file's own `Content-Type`; the ASP.NET Core source says so explicitly (*"these headers are returned for 200, 206, and 304"*).
3. `string.IsNullOrWhiteSpace("<")` is `false`, so #79's empty-template guard did not catch it.

So `StaticFileMiddleware` sliced `index.html`, and the middleware accepted the slice as a whole document.

**Three corrections to the report**, each of which changed the fix:

- **The trigger is much broader than `bytes=0-0`.** *Any satisfiable single range* produces a 206: `bytes=-1`, `bytes=10-20`, even `bytes=0-` (the whole file, under a 206). And since neither `RangeHelper.ParseRange` nor `RangeHeaderValue` validates the range **unit**, `Range: items=0-0` works too. A fix keyed on `bytes=0-0`, or on the `"<"` character, would have been incomplete.
- **Stripping `If-Range` while keeping `Range` was actively harmful, not merely incomplete.** `StaticFileContext.ComputeIfRange` is the *only* code that can cancel an already-parsed range. By removing `If-Range` we guaranteed it never cancelled — so our own header surgery made the range *more* likely to be honoured than if we had touched nothing.
- **Unsatisfiable and multi-range requests were already safe**, for two independent reasons each. An unsatisfiable range yields **416**, which fails the status check *and* gets no `Content-Type` at all. A multi-range or malformed header is *ignored* by ASP.NET Core, which serves a full 200. Neither needed fixing, and both are now pinned as controls so a future change cannot quietly start accepting them.

**Fix.** `Range` is stripped alongside the conditional headers — same method, same reason. It is deliberately **not** restored afterwards, unlike `Accept-Encoding`: that restore is *functionally required*, because upstream compression middleware reads the header when the response starts, whereas nothing downstream of the capture reads `Range`. The asymmetry is commented, or someone will "fix" it.

**Tests.** `Strips_the_range_header_before_the_capture`, `Does_not_restore_the_range_header_after_the_capture` (asserts both halves of the asymmetry in one test, so a reader cannot correct one and miss the other), `Does_not_prerender_a_single_byte_partial_response`.

## 2. The same class, not just the one instance

This was the **third** report of the same shape, and "is this a usable template?" had already been tightened twice — a 2xx + `text/html` check, then an empty-template guard — and a one-byte `<` still walked through. So the fix targets the class.

**What NG05104 actually means**, traced through the render chain: domino **never rejects input** — any byte sequence becomes *a* document — so there is no syntax-error failure mode at all. The single requirement is one line in Angular's renderer: `querySelector(rootSelector)` returning non-null. That is why a plausibility check cannot work, and it is settled by measurement: the `bytes=0-99` slice *starts with* `<!doctype html><html lang="en">` and would pass any "does this look like HTML?" test.

Being 2xx and `text/html` says nothing about completeness, which is the actual requirement. A capture is now rejected unless:

| Check | Closes |
|---|---|
| status is **exactly 200** | 206 from any producer, and every other status |
| no `Content-Range` on the response | a 206 whose status a middleware rewrote — the dev-proxy shape |
| `Content-Encoding` absent or `identity` | a compressed capture decoded as UTF-8 |
| captured bytes == any declared `Content-Length` | truncation, and an unflushed body writer |
| bytes are valid UTF-8, decoding to text with no NUL | a non-UTF-8 charset (UTF-16 markup is byte-wise valid UTF-8 for its ASCII half and decodes to `<\0!\0d\0…`, which is neither empty nor whitespace) |

Status is **exactly 200** rather than "2xx minus the ones we know about", because that fails *closed* on statuses nobody has considered, where the subtractive form fails *open*.

The UTF-8 check runs on the **bytes**, not by inspecting the decoded string for U+FFFD — that cannot distinguish corrupt input from a template legitimately containing a replacement character — and not by decoding with `throwOnInvalidBytes`, which would throw on the request path and leave nothing to log. The decode itself stays lenient, so a truncated capture still cannot throw.

**Tests.** 21 methods / 24 cases in `RangeAndTemplateValidityTests`, including `Does_not_prerender_a_markup_shaped_partial_slice` (which opens with an `Assert.StartsWith` recording *why* plausibility checks fail, so it cannot be mistaken for a duplicate), `Does_not_prerender_a_utf16_encoded_template`, `Prerenders_a_template_containing_a_literal_replacement_character` (pins that U+FFFD is **not** rejected), and 416 / multi-range / malformed-unit controls.

### One reversal worth flagging

The declared-vs-captured length check **reverses a decision made in #79**, which rejected it because `UseWebMarkupMin` legitimately shrinks the body. That premise cannot hold: a middleware leaving a stale `Content-Length` behind would fail Kestrel's own Content-Length verification on *every* response, on every route this middleware never touches. `UseWebMarkupMin` updates the length as it minifies, which is why the demo works at all.

The reinstated form is narrower than what was rejected: only when a length is declared, only one-directionally (a longer capture cannot be a truncation), and logged at Warning — the original objection was really about a *silent* false positive. `Prerenders_a_response_a_transforming_middleware_shrank` models the minifier shape and is the guard: if it ever fails, the reversal was wrong. `SOLUTION-defect2-abort.md` carries a correction box pointing here.

## 3. HEAD responses reported `Content-Length: 0` — a regression shipped in 10.7.0

**Symptom.** A `HEAD` to a SPA route returned `Content-Length: 0` instead of the document's real length. RFC 9110 §9.3.2 requires a HEAD's headers to match the equivalent GET's.

**Cause.** Ours, from #79. `StaticFileMiddleware` answers a HEAD with `200` + `text/html` + the **full** `Content-Length` and no body. #79's empty-template guard caught the empty capture and passed through, and then #79's `Content-Length` reconciliation saw `547 != 0` and "corrected" the length to 0. Kestrel does not complain — `VerifyResponseContentLength` skips HEAD — so nothing caught it. There was no HEAD coverage anywhere in the prerendering tests, which is how it shipped.

**Fix.** Prerendering is now gated to **GET**, which removes the cause at the source: a HEAD never enters the capture, so there is no empty capture, no warning and no rewrite. The reconciliation is *also* narrowed to responses that can carry a body, because 204/205/304 remain reachable on a GET where the gate does nothing.

The gate sits **before the build await**, which matters independently: a `POST` or `OPTIONS` to a SPA route used to block on `ng build` before being turned away downstream.

**Tests.** `RequestMethodGateTests` — 8 methods / 10 cases, including `A_head_request_keeps_the_full_content_length_it_was_given`, `A_head_request_does_not_reach_the_prerenderer` (using a body-writing pipeline, so the empty guard cannot be what saves it), `A_head_request_does_not_wait_for_the_bootmodule_build`, and a `[Theory]` over 204/205/304.

## 4. Warning noise that taught consumers to ignore the category

**Symptom.** #79's empty-template guard logged at **Warning** for every HEAD — every monitoring probe and link checker — while its comment claimed *"There is no known benign cause, so this is worth a warning."* A HEAD is exactly that.

**Fix.** Benign skips (non-GET, a status that carries no body, a client abort) log at **Debug**. Warning is reserved for a response that was supposed to be a document and is not. The log category is now the full type name, so it is filterable through the conventional `Logging:LogLevel:<namespace>` configuration — `"UseSpaPrerendering"` was not.

**Tests.** `A_head_request_does_not_log_a_warning`, `Reports_a_bodyless_status_at_debug_rather_than_warning`.

*(This one was caught by the test author against my first implementation, which logged a benign `204` at Warning as "a partial representation" with an empty `Content-Range`.)*

## 5. The structural diagnostic warned about healthy documents

**Symptom.** A perfectly good minified template — one that visibly starts `<html lang=en>` — was reported as having "no `<html>` element".

**Cause.** The check required both `<html` and `</html>`. Two independent reasons that is wrong: the HTML Living Standard makes the end tags for `html` and `body` **omissible**, so a document ending at `</div>` is not malformed; and removing exactly those tags is a routine minifier optimisation (`RemoveOptionalEndTags` in WebMarkupMin, `removeOptionalTags` in html-minifier-terser). The demo runs `UseWebMarkupMin` *inside* the SPA callback, downstream of the capture, turning a 547-byte `index.html` ending in `</body></html>` into a 456-character template with neither.

**Fix.** Only the opening tag, which is not optional and is not stripped. Found by the end-to-end verification run, not by the unit tests.

**Test.** `Does_not_warn_about_a_minified_template_whose_closing_tags_were_removed`.

---

## Verification

**Unit — both directions.** Reverting the `Range` strip, the GET gate, the framing checks and the bodyless narrowing turns **25 tests red**. Restored: **363 pass**.

**End to end, `Demo.Web` in Production:**

| `Range` | Before | After |
|---|---|---|
| *(none)* | 200, 25252 B | 200, 25252 B |
| `bytes=0-0` | **206 → 500 `NG05104`** | **200, 25252 B, prerendered** |
| `bytes=0-99` | **206 → 500** | **200, 25252 B** |
| `bytes=100-200` | **206 → 500** | **200, 25252 B** |
| `bytes=999999-` | 416 | **200, 25252 B** — see the behaviour note |
| `bytes=0-0,2-2` | 200 | 200, 25252 B |
| `bytes=-1` | *(untested)* | 200, 25252 B |

No 206 reaches the client for any variant, no `Content-Range`, no 500, nothing logged.

- **HEAD**: `curl -I /person` → `Content-Length: 547`, was `0`. One Debug line naming the method, zero Warnings.
- **No regression in #79**: a 200-request real-Chromium `fetch` + `AbortController` burst produced **0 NG05104, 0 5xx**, 195 complete templates — matching the pre-existing run.
- **Baseline untouched**: `/person` still returns 25252 bytes of genuine prerendered markup, 0.03–0.06 s warm. `GET /` still redirects with a 456-byte pass-through rather than a prerendered page.

## Behaviour change for the release notes

**An unsatisfiable range no longer returns `416`; it returns a full `200`.** The header is stripped before `StaticFileMiddleware` sees it, so unsatisfiability can no longer be detected. This is consistent and intended — a server may ignore `Range`, and a prerendered body, generated per request, has no stable byte range to serve — but it is a visible difference from 10.7.0. Documented in the Prerendering README.

## Known limitation, documented rather than hidden

An **error page captured as the template** is not caught. If `UseExceptionHandler` or `UseStatusCodePagesWithReExecute` is registered *inside* the SPA callback, its output is a complete, well-formed `text/html` document that passes every check above — and then fails with `NG05104` because it has no application root element. The library cannot detect this: it does not know your root selector, and guessing it (`<app-` prefixes, "has a hyphenated custom element") converts working deployments into 500s.

The README now warns against that placement and shows the consumer-side assertion in `OnSupplyData`, which is where a check that *does* know the root element belongs. The eventual in-library answer is an opt-in template predicate on `SpaPrerenderingOptions`.

## Versions

All six packages **10.7.0 → 10.7.1**, in lockstep. Behavioural fixes only, no new public API.

Design records are in `docs/`: [PRD](../blob/bugfix/prerendering-range-requests/docs/PRD-Prerendering-Range-Requests.md), [plan](../blob/bugfix/prerendering-range-requests/docs/PLAN-Prerendering-Range-Requests.md), and two `SOLUTION-*.md` files covering the template gate and the HEAD/method gate — including the options that were rejected and why.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
